### PR TITLE
refactor: early-exit useXverse setup on effect cleanup

### DIFF
--- a/.changeset/xverse-listener-leak.md
+++ b/.changeset/xverse-listener-leak.md
@@ -2,4 +2,4 @@
 "@satoshai/kit": patch
 ---
 
-Fix potential useXverse listener leak when the effect cleanup races with the async addListener call.
+Add early-exit checks to useXverse async setup to skip unnecessary work when the effect is cleaned up during pending awaits.

--- a/packages/kit/src/hooks/use-xverse/use-xverse.ts
+++ b/packages/kit/src/hooks/use-xverse/use-xverse.ts
@@ -71,7 +71,7 @@ export const useXverse = ({
                     () => connect('xverse')
                 );
 
-                const unlisten = getSelectedProvider()?.addListener(
+                removeListener = getSelectedProvider()?.addListener(
                     'accountChange',
                     (event: XverseAccountChangeEvent) => {
                         extractAndValidateStacksAddress(
@@ -82,21 +82,6 @@ export const useXverse = ({
                         );
                     }
                 );
-
-                if (cancelled) {
-                    // Effect was cleaned up while we were awaiting —
-                    // remove the listener immediately to prevent a leak.
-                    try {
-                        unlisten?.();
-                    } catch (error) {
-                        console.error(
-                            'Failed to remove Xverse listener after cancel:',
-                            error
-                        );
-                    }
-                } else {
-                    removeListener = unlisten;
-                }
             } catch (error) {
                 console.error('Failed to setup Xverse:', error);
             }


### PR DESCRIPTION
## Summary

- Add `cancelled` flag to useXverse async setup effect
- Early-exit after each `await` if the effect was cleaned up, skipping unnecessary SDK calls and listener registration
- `addListener` is synchronous so there's no actual leak — this is an early-exit optimization

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)