### PR TITLE
feat: expose mutation state on all action hooks

### DIFF
--- a/.changeset/expose-error-state.md
+++ b/.changeset/expose-error-state.md
@@ -1,0 +1,5 @@
+---
+"@satoshai/kit": minor
+---
+
+Expose mutation state on all action hooks, aligned with wagmi's pattern. `useConnect`, `useDisconnect`, `useSignMessage`, and `useWriteContract` now return `error`, `isError`, `isIdle`, `isPending`, `isSuccess`, `status`, and `reset`. Adds `MutationStatus` type export.

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -36,15 +36,18 @@
     "bns-v2-sdk": "^2.1.0"
   },
   "peerDependencies": {
+    "@stacks/transactions": ">=7.0.0",
     "react": "^18.0.0 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0",
-    "@stacks/transactions": ">=7.0.0"
+    "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@stacks/transactions": "^7.2.0",
+    "@testing-library/react": "^16.3.2",
+    "@types/node": "^22.0.0",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
-    "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.2.4",
+    "happy-dom": "^20.7.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tsup": "^8.3.0",

--- a/packages/kit/src/hooks/use-connect.ts
+++ b/packages/kit/src/hooks/use-connect.ts
@@ -1,20 +1,78 @@
-"use client";
+'use client';
 
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from 'react';
 
-import { useStacksWalletContext } from "../provider/stacks-wallet-provider";
+import type { SupportedStacksWallet } from '../constants/wallets';
+import type { ConnectOptions, MutationStatus } from '../provider/stacks-wallet-provider.types';
+import { useStacksWalletContext } from '../provider/stacks-wallet-provider';
 
 export const useConnect = () => {
-  const { connect, reset, status } = useStacksWalletContext();
+    const {
+        connect: contextConnect,
+        reset: contextReset,
+        status: walletStatus,
+    } = useStacksWalletContext();
 
-  const value = useMemo(
-    () => ({
-      connect,
-      reset,
-      isPending: status === "connecting",
-    }),
-    [connect, reset, status]
-  );
+    const [error, setError] = useState<Error | null>(null);
+    const [mutationStatus, setMutationStatus] =
+        useState<MutationStatus>('idle');
 
-  return value;
+    const connect = useCallback(
+        async (
+            providerId: SupportedStacksWallet,
+            options?: ConnectOptions
+        ) => {
+            setError(null);
+            setMutationStatus('pending');
+
+            let settled = false;
+
+            try {
+                await contextConnect(providerId, {
+                    onSuccess: (address, provider) => {
+                        settled = true;
+                        setMutationStatus('success');
+                        options?.onSuccess?.(address, provider);
+                    },
+                    onError: (err) => {
+                        settled = true;
+                        setError(err);
+                        setMutationStatus('error');
+                        options?.onError?.(err);
+                    },
+                });
+            } finally {
+                if (!settled) {
+                    // connect returned without calling onSuccess or onError
+                    // (e.g., cancelled by reset or stale generation)
+                    setMutationStatus('idle');
+                }
+            }
+        },
+        [contextConnect]
+    );
+
+    const reset = useCallback(() => {
+        setError(null);
+        setMutationStatus('idle');
+        contextReset();
+    }, [contextReset]);
+
+    const value = useMemo(
+        () => ({
+            connect,
+            reset,
+            error,
+            isError: mutationStatus === 'error',
+            isIdle: mutationStatus === 'idle',
+            isPending:
+                mutationStatus === 'pending' ||
+                walletStatus === 'connecting',
+            isSuccess: mutationStatus === 'success',
+            status: mutationStatus,
+        }),
+        [connect, reset, error, mutationStatus, walletStatus]
+    );
+
+    return value;
 };

--- a/packages/kit/src/hooks/use-disconnect.ts
+++ b/packages/kit/src/hooks/use-disconnect.ts
@@ -1,16 +1,52 @@
-"use client";
+'use client';
 
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from 'react';
 
-import { useStacksWalletContext } from "../provider/stacks-wallet-provider";
+import type { MutationStatus } from '../provider/stacks-wallet-provider.types';
+import { useStacksWalletContext } from '../provider/stacks-wallet-provider';
 
 export const useDisconnect = () => {
-  const { disconnect } = useStacksWalletContext();
+    const { disconnect: contextDisconnect } = useStacksWalletContext();
 
-  return useMemo(
-    () => ({
-      disconnect,
-    }),
-    [disconnect]
-  );
+    const [error, setError] = useState<Error | null>(null);
+    const [mutationStatus, setMutationStatus] =
+        useState<MutationStatus>('idle');
+
+    const disconnect = useCallback(
+        (callback?: () => void) => {
+            setError(null);
+
+            try {
+                contextDisconnect(callback);
+                setMutationStatus('success');
+            } catch (err) {
+                const normalizedError =
+                    err instanceof Error ? err : new Error(String(err));
+                setError(normalizedError);
+                setMutationStatus('error');
+            }
+        },
+        [contextDisconnect]
+    );
+
+    const reset = useCallback(() => {
+        setError(null);
+        setMutationStatus('idle');
+    }, []);
+
+    const value = useMemo(
+        () => ({
+            disconnect,
+            reset,
+            error,
+            isError: mutationStatus === 'error',
+            isIdle: mutationStatus === 'idle',
+            isPending: mutationStatus === 'pending',
+            isSuccess: mutationStatus === 'success',
+            status: mutationStatus,
+        }),
+        [disconnect, reset, error, mutationStatus]
+    );
+
+    return value;
 };

--- a/packages/kit/src/hooks/use-sign-message.ts
+++ b/packages/kit/src/hooks/use-sign-message.ts
@@ -1,8 +1,9 @@
 'use client';
 
 import { request } from '@stacks/connect';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
+import type { MutationStatus } from '../provider/stacks-wallet-provider.types';
 import { useAddress } from './use-address';
 
 export interface SignMessageVariables {
@@ -28,7 +29,7 @@ export const useSignMessage = () => {
     const { isConnected, provider } = useAddress();
     const [data, setData] = useState<SignMessageData | undefined>(undefined);
     const [error, setError] = useState<Error | null>(null);
-    const [isPending, setIsPending] = useState(false);
+    const [status, setStatus] = useState<MutationStatus>('idle');
 
     const signMessageAsync = useCallback(
         async (variables: SignMessageVariables): Promise<SignMessageData> => {
@@ -36,7 +37,7 @@ export const useSignMessage = () => {
                 throw new Error('Wallet is not connected');
             }
 
-            setIsPending(true);
+            setStatus('pending');
             setError(null);
             setData(undefined);
 
@@ -61,13 +62,13 @@ export const useSignMessage = () => {
                 }
 
                 setData(result);
-                setIsPending(false);
+                setStatus('success');
                 return result;
             } catch (err) {
                 const error =
                     err instanceof Error ? err : new Error(String(err));
                 setError(error);
-                setIsPending(false);
+                setStatus('error');
                 throw error;
             }
         },
@@ -89,11 +90,25 @@ export const useSignMessage = () => {
         [signMessageAsync]
     );
 
-    return {
-        signMessage,
-        signMessageAsync,
-        data,
-        error,
-        isPending,
-    };
+    const reset = useCallback(() => {
+        setData(undefined);
+        setError(null);
+        setStatus('idle');
+    }, []);
+
+    return useMemo(
+        () => ({
+            signMessage,
+            signMessageAsync,
+            reset,
+            data,
+            error,
+            isError: status === 'error',
+            isIdle: status === 'idle',
+            isPending: status === 'pending',
+            isSuccess: status === 'success',
+            status,
+        }),
+        [signMessage, signMessageAsync, reset, data, error, status]
+    );
 };

--- a/packages/kit/src/hooks/use-write-contract/use-write-contract.ts
+++ b/packages/kit/src/hooks/use-write-contract/use-write-contract.ts
@@ -2,8 +2,9 @@
 
 import { request } from '@stacks/connect';
 import { PostConditionMode } from '@stacks/transactions';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
+import type { MutationStatus } from '../../provider/stacks-wallet-provider.types';
 import { useAddress } from '../use-address';
 import { getNetworkFromAddress } from '../../utils/get-network-from-address';
 
@@ -21,7 +22,7 @@ export const useWriteContract = () => {
 
     const [data, setData] = useState<string | undefined>(undefined);
     const [error, setError] = useState<Error | null>(null);
-    const [isPending, setIsPending] = useState(false);
+    const [status, setStatus] = useState<MutationStatus>('idle');
 
     const writeContractAsync = useCallback(
         async (variables: WriteContractVariables): Promise<string> => {
@@ -29,7 +30,7 @@ export const useWriteContract = () => {
                 throw new Error('Wallet is not connected');
             }
 
-            setIsPending(true);
+            setStatus('pending');
             setError(null);
             setData(undefined);
 
@@ -55,7 +56,7 @@ export const useWriteContract = () => {
                         });
 
                     setData(response.txHash);
-                    setIsPending(false);
+                    setStatus('success');
                     return response.txHash;
                 }
 
@@ -77,13 +78,13 @@ export const useWriteContract = () => {
                 }
 
                 setData(response.txid);
-                setIsPending(false);
+                setStatus('success');
                 return response.txid;
             } catch (err) {
                 const error =
                     err instanceof Error ? err : new Error(String(err));
                 setError(error);
-                setIsPending(false);
+                setStatus('error');
                 throw error;
             }
         },
@@ -105,13 +106,27 @@ export const useWriteContract = () => {
         [writeContractAsync]
     );
 
-    return {
-        writeContract,
-        writeContractAsync,
-        data,
-        error,
-        isPending,
-    };
+    const reset = useCallback(() => {
+        setData(undefined);
+        setError(null);
+        setStatus('idle');
+    }, []);
+
+    return useMemo(
+        () => ({
+            writeContract,
+            writeContractAsync,
+            reset,
+            data,
+            error,
+            isError: status === 'error',
+            isIdle: status === 'idle',
+            isPending: status === 'pending',
+            isSuccess: status === 'success',
+            status,
+        }),
+        [writeContract, writeContractAsync, reset, data, error, status]
+    );
 };
 
 export type {

--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -28,6 +28,7 @@ export type {
     WalletInfo,
     StacksChain,
     ConnectOptions,
+    MutationStatus,
 } from './provider/stacks-wallet-provider.types';
 
 // Constants

--- a/packages/kit/src/provider/stacks-wallet-provider.types.ts
+++ b/packages/kit/src/provider/stacks-wallet-provider.types.ts
@@ -2,6 +2,8 @@ import type { SupportedStacksWallet } from '../constants/wallets';
 
 export type StacksChain = 'mainnet' | 'testnet';
 
+export type MutationStatus = 'idle' | 'pending' | 'error' | 'success';
+
 export interface WalletConnectMetadata {
     name: string;
     description: string;

--- a/packages/kit/tests/unit/hooks/use-connect.test.ts
+++ b/packages/kit/tests/unit/hooks/use-connect.test.ts
@@ -1,0 +1,215 @@
+// @vitest-environment happy-dom
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { WalletContextValue } from '../../../src/provider/stacks-wallet-provider.types';
+
+const mockContext: WalletContextValue = {
+    status: 'disconnected',
+    address: undefined,
+    provider: undefined,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    reset: vi.fn(),
+    wallets: [],
+};
+
+vi.mock('../../../src/provider/stacks-wallet-provider', () => ({
+    useStacksWalletContext: () => mockContext,
+}));
+
+// Import after mock is set up
+const { useConnect } = await import('../../../src/hooks/use-connect');
+
+beforeEach(() => {
+    vi.mocked(mockContext.connect).mockReset();
+    vi.mocked(mockContext.reset).mockReset();
+    mockContext.status = 'disconnected';
+});
+
+describe('useConnect', () => {
+    it('returns idle state initially', () => {
+        const { result } = renderHook(() => useConnect());
+
+        expect(result.current.status).toBe('idle');
+        expect(result.current.isIdle).toBe(true);
+        expect(result.current.isPending).toBe(false);
+        expect(result.current.isSuccess).toBe(false);
+        expect(result.current.isError).toBe(false);
+        expect(result.current.error).toBeNull();
+    });
+
+    it('transitions to pending when connect is called', async () => {
+        // connect never resolves — we just want to observe the pending state
+        vi.mocked(mockContext.connect).mockImplementation(
+            () => new Promise(() => {})
+        );
+
+        const { result } = renderHook(() => useConnect());
+
+        // Don't await — we want to check intermediate state
+        act(() => {
+            void result.current.connect('xverse');
+        });
+
+        expect(result.current.status).toBe('pending');
+        expect(result.current.isPending).toBe(true);
+        expect(result.current.isIdle).toBe(false);
+    });
+
+    it('transitions to success when connect succeeds', async () => {
+        vi.mocked(mockContext.connect).mockImplementation(
+            async (_providerId, options) => {
+                options?.onSuccess?.('SP123', 'xverse');
+            }
+        );
+
+        const { result } = renderHook(() => useConnect());
+
+        await act(async () => {
+            await result.current.connect('xverse');
+        });
+
+        expect(result.current.status).toBe('success');
+        expect(result.current.isSuccess).toBe(true);
+        expect(result.current.error).toBeNull();
+    });
+
+    it('transitions to error when connect fails', async () => {
+        const testError = new Error('Wallet not installed');
+
+        vi.mocked(mockContext.connect).mockImplementation(
+            async (_providerId, options) => {
+                options?.onError?.(testError);
+            }
+        );
+
+        const { result } = renderHook(() => useConnect());
+
+        await act(async () => {
+            await result.current.connect('xverse');
+        });
+
+        expect(result.current.status).toBe('error');
+        expect(result.current.isError).toBe(true);
+        expect(result.current.error).toBe(testError);
+    });
+
+    it('forwards onSuccess callback to consumer', async () => {
+        vi.mocked(mockContext.connect).mockImplementation(
+            async (_providerId, options) => {
+                options?.onSuccess?.('SP123', 'xverse');
+            }
+        );
+
+        const onSuccess = vi.fn();
+        const { result } = renderHook(() => useConnect());
+
+        await act(async () => {
+            await result.current.connect('xverse', { onSuccess });
+        });
+
+        expect(onSuccess).toHaveBeenCalledWith('SP123', 'xverse');
+    });
+
+    it('forwards onError callback to consumer', async () => {
+        const testError = new Error('Connection failed');
+
+        vi.mocked(mockContext.connect).mockImplementation(
+            async (_providerId, options) => {
+                options?.onError?.(testError);
+            }
+        );
+
+        const onError = vi.fn();
+        const { result } = renderHook(() => useConnect());
+
+        await act(async () => {
+            await result.current.connect('xverse', { onError });
+        });
+
+        expect(onError).toHaveBeenCalledWith(testError);
+    });
+
+    it('resets to idle when connect returns without settling (cancelled)', async () => {
+        // Simulate provider's stale-generation bail: returns without calling onSuccess/onError
+        vi.mocked(mockContext.connect).mockResolvedValue(undefined);
+
+        const { result } = renderHook(() => useConnect());
+
+        await act(async () => {
+            await result.current.connect('xverse');
+        });
+
+        expect(result.current.status).toBe('idle');
+        expect(result.current.isIdle).toBe(true);
+        expect(result.current.error).toBeNull();
+    });
+
+    it('clears previous error when starting a new connect', async () => {
+        const testError = new Error('First failure');
+
+        vi.mocked(mockContext.connect).mockImplementation(
+            async (_providerId, options) => {
+                options?.onError?.(testError);
+            }
+        );
+
+        const { result } = renderHook(() => useConnect());
+
+        await act(async () => {
+            await result.current.connect('xverse');
+        });
+
+        expect(result.current.isError).toBe(true);
+
+        // Now start a new connect that never settles
+        vi.mocked(mockContext.connect).mockImplementation(
+            () => new Promise(() => {})
+        );
+
+        act(() => {
+            void result.current.connect('leather');
+        });
+
+        expect(result.current.error).toBeNull();
+        expect(result.current.status).toBe('pending');
+    });
+
+    it('reset clears error and status back to idle', async () => {
+        const testError = new Error('Failed');
+
+        vi.mocked(mockContext.connect).mockImplementation(
+            async (_providerId, options) => {
+                options?.onError?.(testError);
+            }
+        );
+
+        const { result } = renderHook(() => useConnect());
+
+        await act(async () => {
+            await result.current.connect('xverse');
+        });
+
+        expect(result.current.isError).toBe(true);
+
+        act(() => {
+            result.current.reset();
+        });
+
+        expect(result.current.status).toBe('idle');
+        expect(result.current.isIdle).toBe(true);
+        expect(result.current.error).toBeNull();
+        expect(mockContext.reset).toHaveBeenCalled();
+    });
+
+    it('reflects walletStatus connecting in isPending', () => {
+        mockContext.status = 'connecting';
+
+        const { result } = renderHook(() => useConnect());
+
+        expect(result.current.isPending).toBe(true);
+        // mutation status itself is still idle
+        expect(result.current.status).toBe('idle');
+    });
+});

--- a/packages/kit/tests/unit/hooks/use-disconnect.test.ts
+++ b/packages/kit/tests/unit/hooks/use-disconnect.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment happy-dom
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { WalletContextValue } from '../../../src/provider/stacks-wallet-provider.types';
+
+const mockContext: WalletContextValue = {
+    status: 'connected',
+    address: 'SP123',
+    provider: 'xverse',
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    reset: vi.fn(),
+    wallets: [],
+};
+
+vi.mock('../../../src/provider/stacks-wallet-provider', () => ({
+    useStacksWalletContext: () => mockContext,
+}));
+
+const { useDisconnect } = await import('../../../src/hooks/use-disconnect');
+
+beforeEach(() => {
+    vi.mocked(mockContext.disconnect).mockReset();
+});
+
+describe('useDisconnect', () => {
+    it('returns idle state initially', () => {
+        const { result } = renderHook(() => useDisconnect());
+
+        expect(result.current.status).toBe('idle');
+        expect(result.current.isIdle).toBe(true);
+        expect(result.current.isPending).toBe(false);
+        expect(result.current.isSuccess).toBe(false);
+        expect(result.current.isError).toBe(false);
+        expect(result.current.error).toBeNull();
+    });
+
+    it('transitions to success on disconnect', () => {
+        const { result } = renderHook(() => useDisconnect());
+
+        act(() => {
+            result.current.disconnect();
+        });
+
+        expect(result.current.status).toBe('success');
+        expect(result.current.isSuccess).toBe(true);
+        expect(result.current.error).toBeNull();
+        expect(mockContext.disconnect).toHaveBeenCalled();
+    });
+
+    it('forwards callback to context disconnect', () => {
+        const callback = vi.fn();
+        const { result } = renderHook(() => useDisconnect());
+
+        act(() => {
+            result.current.disconnect(callback);
+        });
+
+        expect(mockContext.disconnect).toHaveBeenCalledWith(callback);
+    });
+
+    it('transitions to error when disconnect throws', () => {
+        vi.mocked(mockContext.disconnect).mockImplementation(() => {
+            throw new Error('Disconnect failed');
+        });
+
+        const { result } = renderHook(() => useDisconnect());
+
+        act(() => {
+            result.current.disconnect();
+        });
+
+        expect(result.current.status).toBe('error');
+        expect(result.current.isError).toBe(true);
+        expect(result.current.error?.message).toBe('Disconnect failed');
+    });
+
+    it('normalizes non-Error throws', () => {
+        vi.mocked(mockContext.disconnect).mockImplementation(() => {
+            throw 'string error';
+        });
+
+        const { result } = renderHook(() => useDisconnect());
+
+        act(() => {
+            result.current.disconnect();
+        });
+
+        expect(result.current.error).toBeInstanceOf(Error);
+        expect(result.current.error?.message).toBe('string error');
+    });
+
+    it('clears previous error on new disconnect', () => {
+        vi.mocked(mockContext.disconnect).mockImplementation(() => {
+            throw new Error('First failure');
+        });
+
+        const { result } = renderHook(() => useDisconnect());
+
+        act(() => {
+            result.current.disconnect();
+        });
+
+        expect(result.current.isError).toBe(true);
+
+        // Second disconnect succeeds
+        vi.mocked(mockContext.disconnect).mockImplementation(() => {});
+
+        act(() => {
+            result.current.disconnect();
+        });
+
+        expect(result.current.status).toBe('success');
+        expect(result.current.error).toBeNull();
+    });
+
+    it('reset clears state back to idle', () => {
+        const { result } = renderHook(() => useDisconnect());
+
+        act(() => {
+            result.current.disconnect();
+        });
+
+        expect(result.current.isSuccess).toBe(true);
+
+        act(() => {
+            result.current.reset();
+        });
+
+        expect(result.current.status).toBe('idle');
+        expect(result.current.isIdle).toBe(true);
+        expect(result.current.error).toBeNull();
+    });
+});

--- a/packages/kit/tests/unit/hooks/use-sign-message.test.ts
+++ b/packages/kit/tests/unit/hooks/use-sign-message.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment happy-dom
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockRequest = vi.fn();
+vi.mock('@stacks/connect', () => ({
+    request: mockRequest,
+}));
+
+vi.mock('../../../src/hooks/use-address', () => ({
+    useAddress: () => ({
+        isConnected: true,
+        provider: 'leather',
+        address: 'SP123',
+    }),
+}));
+
+const { useSignMessage } = await import(
+    '../../../src/hooks/use-sign-message'
+);
+
+beforeEach(() => {
+    mockRequest.mockReset();
+});
+
+describe('useSignMessage', () => {
+    it('returns idle state initially', () => {
+        const { result } = renderHook(() => useSignMessage());
+
+        expect(result.current.status).toBe('idle');
+        expect(result.current.isIdle).toBe(true);
+        expect(result.current.isPending).toBe(false);
+        expect(result.current.isSuccess).toBe(false);
+        expect(result.current.isError).toBe(false);
+        expect(result.current.error).toBeNull();
+        expect(result.current.data).toBeUndefined();
+    });
+
+    it('transitions to success with data', async () => {
+        const mockResult = { publicKey: 'pk123', signature: 'sig123' };
+        mockRequest.mockResolvedValue(mockResult);
+
+        const { result } = renderHook(() => useSignMessage());
+
+        await act(async () => {
+            await result.current.signMessageAsync({ message: 'hello' });
+        });
+
+        expect(result.current.status).toBe('success');
+        expect(result.current.isSuccess).toBe(true);
+        expect(result.current.data).toEqual(mockResult);
+        expect(result.current.error).toBeNull();
+    });
+
+    it('transitions to error on failure', async () => {
+        mockRequest.mockRejectedValue(new Error('User rejected'));
+
+        const { result } = renderHook(() => useSignMessage());
+
+        await act(async () => {
+            await expect(
+                result.current.signMessageAsync({ message: 'hello' })
+            ).rejects.toThrow('User rejected');
+        });
+
+        expect(result.current.status).toBe('error');
+        expect(result.current.isError).toBe(true);
+        expect(result.current.error?.message).toBe('User rejected');
+        expect(result.current.data).toBeUndefined();
+    });
+
+    it('signMessageAsync returns data on success', async () => {
+        const mockResult = { publicKey: 'pk123', signature: 'sig123' };
+        mockRequest.mockResolvedValue(mockResult);
+
+        const { result } = renderHook(() => useSignMessage());
+
+        let data: unknown;
+        await act(async () => {
+            data = await result.current.signMessageAsync({
+                message: 'hello',
+            });
+        });
+
+        expect(data).toEqual(mockResult);
+    });
+
+    it('calls onSuccess and onSettled callbacks via signMessage', async () => {
+        const mockResult = { publicKey: 'pk123', signature: 'sig123' };
+        mockRequest.mockResolvedValue(mockResult);
+
+        const onSuccess = vi.fn();
+        const onSettled = vi.fn();
+
+        const { result } = renderHook(() => useSignMessage());
+
+        await act(async () => {
+            result.current.signMessage(
+                { message: 'hello' },
+                { onSuccess, onSettled }
+            );
+            // Wait for the fire-and-forget promise to settle
+            await new Promise((r) => setTimeout(r, 0));
+        });
+
+        expect(onSuccess).toHaveBeenCalledWith(mockResult);
+        expect(onSettled).toHaveBeenCalledWith(mockResult, null);
+    });
+
+    it('calls onError and onSettled callbacks on failure via signMessage', async () => {
+        mockRequest.mockRejectedValue(new Error('Rejected'));
+
+        const onError = vi.fn();
+        const onSettled = vi.fn();
+
+        const { result } = renderHook(() => useSignMessage());
+
+        await act(async () => {
+            result.current.signMessage(
+                { message: 'hello' },
+                { onError, onSettled }
+            );
+            await new Promise((r) => setTimeout(r, 0));
+        });
+
+        expect(onError).toHaveBeenCalledWith(expect.any(Error));
+        expect(onSettled).toHaveBeenCalledWith(undefined, expect.any(Error));
+    });
+
+    it('reset clears data, error, and status', async () => {
+        const mockResult = { publicKey: 'pk123', signature: 'sig123' };
+        mockRequest.mockResolvedValue(mockResult);
+
+        const { result } = renderHook(() => useSignMessage());
+
+        await act(async () => {
+            await result.current.signMessageAsync({ message: 'hello' });
+        });
+
+        expect(result.current.data).toEqual(mockResult);
+
+        act(() => {
+            result.current.reset();
+        });
+
+        expect(result.current.status).toBe('idle');
+        expect(result.current.isIdle).toBe(true);
+        expect(result.current.data).toBeUndefined();
+        expect(result.current.error).toBeNull();
+    });
+
+    it('clears previous error on new call', async () => {
+        mockRequest.mockRejectedValue(new Error('First failure'));
+
+        const { result } = renderHook(() => useSignMessage());
+
+        await act(async () => {
+            await expect(
+                result.current.signMessageAsync({ message: 'hello' })
+            ).rejects.toThrow();
+        });
+
+        expect(result.current.isError).toBe(true);
+
+        const mockResult = { publicKey: 'pk123', signature: 'sig123' };
+        mockRequest.mockResolvedValue(mockResult);
+
+        await act(async () => {
+            await result.current.signMessageAsync({ message: 'retry' });
+        });
+
+        expect(result.current.isSuccess).toBe(true);
+        expect(result.current.error).toBeNull();
+        expect(result.current.data).toEqual(mockResult);
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       '@stacks/transactions':
         specifier: ^7.2.0
         version: 7.3.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.11
@@ -82,6 +85,12 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.2
         version: 19.2.3(@types/react@19.2.14)
+      '@vitest/coverage-v8':
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4(@types/node@22.19.11)(happy-dom@20.7.0)(jiti@2.6.1))
+      happy-dom:
+        specifier: ^20.7.0
+        version: 20.7.0
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -96,12 +105,16 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)
+        version: 3.2.4(@types/node@22.19.11)(happy-dom@20.7.0)(jiti@2.6.1)
 
 packages:
 
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -189,6 +202,10 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@bitcoinerlab/secp256k1@1.2.0':
     resolution: {integrity: sha512-jeujZSzb3JOZfmJYI0ph1PVpCRV5oaexCgy+RvCXV8XlY+XFB/2n3WOcvBsKLsOw78KYgnQrQWb2HrKE4be88Q==}
@@ -692,6 +709,14 @@ packages:
       '@types/node':
         optional: true
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.3':
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -777,6 +802,10 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@reown/appkit-common@1.7.17':
     resolution: {integrity: sha512-zfrlNosQ5XBGC7OBG56+lur0nJWCdRKoWVlUnr0dCVVfBmHIgdhFkRNzDqrX/zGqg4OoWDQLO7qaGiijRskfBQ==}
@@ -1024,6 +1053,28 @@ packages:
     engines: {node: '>=16.0.0', npm: '>=7.10.0'}
     hasBin: true
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -1070,6 +1121,12 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.56.0':
     resolution: {integrity: sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw==}
@@ -1135,6 +1192,15 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@vitest/coverage-v8@3.2.4':
+    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+    peerDependencies:
+      '@vitest/browser': 3.2.4
+      vitest: 3.2.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -1290,9 +1356,21 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -1307,6 +1385,9 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
   array-ify@1.0.0:
     resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
 
@@ -1317,6 +1398,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.11:
+    resolution: {integrity: sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==}
 
   async@2.6.4:
     resolution: {integrity: sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==}
@@ -1653,6 +1737,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
@@ -1670,6 +1758,9 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
@@ -1685,6 +1776,9 @@ packages:
   duplexify@4.1.3:
     resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   ecpair@2.1.0:
     resolution: {integrity: sha512-cL/mh3MtJutFOvFc27GPZE2pWL3a3k4YvzUWEOvilnfZVlH3Jwgx/7d6tlD7/75tNk8TG2m+7Kgtz0SI1tWcqw==}
     engines: {node: '>=8.0.0'}
@@ -1698,6 +1792,9 @@ packages:
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
   encode-utf8@1.0.3:
     resolution: {integrity: sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==}
 
@@ -1707,6 +1804,10 @@ packages:
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -1907,6 +2008,10 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
@@ -1956,6 +2061,11 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
     engines: {node: '>=18'}
@@ -1977,6 +2087,10 @@ packages:
 
   h3@1.15.5:
     resolution: {integrity: sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==}
+
+  happy-dom@20.7.0:
+    resolution: {integrity: sha512-hR/uLYQdngTyEfxnOoa+e6KTcfBFyc1hgFj/Cc144A5JJUuHFYqIEBDcD4FeGqUeKLRZqJ9eN9u7/GDjYEgS1g==}
+    engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -2006,6 +2120,9 @@ packages:
 
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
@@ -2112,6 +2229,25 @@ packages:
     peerDependencies:
       ws: '*'
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -2119,6 +2255,9 @@ packages:
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2233,6 +2372,9 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@11.2.6:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
     engines: {node: 20 || >=22}
@@ -2240,8 +2382,19 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2280,6 +2433,10 @@ packages:
   minimalistic-crypto-utils@1.0.1:
     resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
 
+  minimatch@10.2.4:
+    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.3:
     resolution: {integrity: sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==}
 
@@ -2289,6 +2446,10 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
@@ -2418,6 +2579,9 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
@@ -2436,6 +2600,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -2519,6 +2687,10 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
@@ -2563,6 +2735,9 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -2744,6 +2919,10 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
@@ -2753,6 +2932,10 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -2781,6 +2964,10 @@ packages:
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -3102,6 +3289,10 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
@@ -3136,6 +3327,10 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -3216,6 +3411,11 @@ packages:
 snapshots:
 
   '@adraffy/ens-normalize@1.11.1': {}
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -3330,6 +3530,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@bitcoinerlab/secp256k1@1.2.0':
     dependencies:
@@ -3809,6 +4011,17 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.11
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.3': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3896,6 +4109,9 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@reown/appkit-common@1.7.17(typescript@5.9.3)(zod@3.22.4)':
     dependencies:
@@ -4455,6 +4671,29 @@ snapshots:
       '@rollup/rollup-win32-arm64-msvc': 4.44.0
       '@rollup/rollup-win32-x64-msvc': 4.44.0
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.28.6
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@types/aria-query@5.0.4': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.0
@@ -4510,6 +4749,12 @@ snapshots:
       csstype: 3.2.3
 
   '@types/trusted-types@2.0.7': {}
+
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.11
 
   '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -4611,6 +4856,25 @@ snapshots:
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
       vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@22.19.11)(happy-dom@20.7.0)(jiti@2.6.1))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.11
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/node@22.19.11)(happy-dom@20.7.0)(jiti@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5002,9 +5266,15 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.2.2: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
+
+  ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
 
@@ -5019,11 +5289,21 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
   array-ify@1.0.0: {}
 
   array-union@2.1.0: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.11:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   async@2.6.4:
     dependencies:
@@ -5411,6 +5691,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  dequal@2.0.3: {}
+
   destr@2.0.5: {}
 
   detect-browser@5.3.0: {}
@@ -5422,6 +5704,8 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dom-accessibility-api@0.5.16: {}
 
   dot-prop@5.3.0:
     dependencies:
@@ -5447,6 +5731,8 @@ snapshots:
       readable-stream: 3.6.2
       stream-shift: 1.0.3
 
+  eastasianwidth@0.2.0: {}
+
   ecpair@2.1.0:
     dependencies:
       randombytes: 2.1.0
@@ -5469,6 +5755,8 @@ snapshots:
 
   emoji-regex@8.0.0: {}
 
+  emoji-regex@9.2.2: {}
+
   encode-utf8@1.0.3: {}
 
   end-of-stream@1.4.5:
@@ -5479,6 +5767,8 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  entities@7.0.1: {}
 
   env-paths@2.2.1: {}
 
@@ -5729,6 +6019,11 @@ snapshots:
       is-callable: 1.2.7
     optional: true
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -5790,6 +6085,15 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.6
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   global-directory@4.0.1:
     dependencies:
       ini: 4.1.1
@@ -5820,6 +6124,18 @@ snapshots:
       radix3: 1.1.2
       ufo: 1.6.3
       uncrypto: 0.1.3
+
+  happy-dom@20.7.0:
+    dependencies:
+      '@types/node': 22.19.11
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@4.0.0: {}
 
@@ -5858,6 +6174,8 @@ snapshots:
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
     optional: true
+
+  html-escaper@2.0.2: {}
 
   human-id@4.1.3: {}
 
@@ -5936,9 +6254,38 @@ snapshots:
     dependencies:
       ws: 8.18.3
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jiti@2.6.1: {}
 
   joycon@3.1.1: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -6038,15 +6385,29 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@10.4.3: {}
+
   lru-cache@11.2.6: {}
 
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   math-intrinsics@1.1.0: {}
 
@@ -6080,6 +6441,10 @@ snapshots:
   minimalistic-crypto-utils@1.0.1:
     optional: true
 
+  minimatch@10.2.4:
+    dependencies:
+      brace-expansion: 5.0.3
+
   minimatch@3.1.3:
     dependencies:
       brace-expansion: 1.1.12
@@ -6089,6 +6454,8 @@ snapshots:
       brace-expansion: 5.0.3
 
   minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
 
   mlly@1.8.0:
     dependencies:
@@ -6229,6 +6596,8 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  package-json-from-dist@1.0.1: {}
+
   package-manager-detector@0.2.11:
     dependencies:
       quansync: 0.2.11
@@ -6247,6 +6616,11 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   path-type@4.0.0: {}
 
@@ -6313,6 +6687,12 @@ snapshots:
 
   prettier@2.8.8: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   process-nextick-args@2.0.1:
     optional: true
 
@@ -6355,6 +6735,8 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react-refresh@0.17.0: {}
 
@@ -6547,6 +6929,12 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
   string_decoder@1.1.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -6559,6 +6947,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
 
@@ -6585,6 +6977,12 @@ snapshots:
   tagged-tag@1.0.0: {}
 
   term-size@2.2.1: {}
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 10.5.0
+      minimatch: 10.2.4
 
   thenify-all@1.6.0:
     dependencies:
@@ -6837,7 +7235,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vitest@3.2.4(@types/node@22.19.11)(jiti@2.6.1):
+  vitest@3.2.4(@types/node@22.19.11)(happy-dom@20.7.0)(jiti@2.6.1):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -6864,6 +7262,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.11
+      happy-dom: 20.7.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -6879,6 +7278,8 @@ snapshots:
       - yaml
 
   webidl-conversions@3.0.1: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   whatwg-url@5.0.0:
     dependencies:
@@ -6925,6 +7326,12 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
 


### PR DESCRIPTION
## Summary

- Align `useConnect`, `useDisconnect`, `useSignMessage`, and `useWriteContract` with wagmi's mutation pattern
- All action hooks now return `error`, `isError`, `isIdle`, `isPending`, `isSuccess`, `status`, and `reset`
- Mutation state managed locally per hook instance (not in shared provider context)
- Stabilize all hook returns with `useMemo` to prevent unnecessary re-renders
- Add `MutationStatus` type export

## API

```tsx
const { connect, reset, error, isError, isIdle, isPending, isSuccess, status } = useConnect();
const { disconnect, reset, error, isError, isIdle, isPending, isSuccess, status } = useDisconnect();
const { signMessage, signMessageAsync, reset, data, error, isError, isIdle, isPending, isSuccess, status } = useSignMessage();
const { writeContract, writeContractAsync, reset, data, error, isError, isIdle, isPending, isSuccess, status } = useWriteContract();
```

## Test plan

- [x] 25 new hook tests with `@testing-library/react` + `happy-dom`
- [x] 100% coverage on `useConnect` and `useDisconnect`
- [x] 87.6% coverage on `useSignMessage` (remaining gaps are OKX-specific paths — tracked in #14)
- [x] All 65 tests pass, lint, typecheck, build green

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)