### PR TITLE
fix: return false for extension wallets during SSR

### DIFF
--- a/.changeset/fix-ssr-hydration.md
+++ b/.changeset/fix-ssr-hydration.md
@@ -1,0 +1,5 @@
+---
+'@satoshai/kit': patch
+---
+
+Fix SSR hydration mismatch by returning false for extension-based wallets when window is undefined

--- a/packages/kit/src/utils/get-stacks-wallets.ts
+++ b/packages/kit/src/utils/get-stacks-wallets.ts
@@ -20,7 +20,7 @@ export const getStacksWallets = (): StacksWallets => {
 export const checkIfStacksProviderIsInstalled = (
     wallet: SupportedStacksWallet
 ): boolean => {
-    if (typeof window === 'undefined') return true;
+    if (typeof window === 'undefined') return wallet === 'wallet-connect';
 
     /* eslint-disable @typescript-eslint/no-explicit-any */
     switch (wallet) {

--- a/packages/kit/tests/unit/utils/get-stacks-wallets.test.ts
+++ b/packages/kit/tests/unit/utils/get-stacks-wallets.test.ts
@@ -38,9 +38,18 @@ describe('checkIfStacksProviderIsInstalled', () => {
         vi.stubGlobal('window', {} as Window);
     });
 
-    it('returns true when window is undefined (SSR)', () => {
+    it('returns false for extension wallets when window is undefined (SSR)', () => {
         vi.stubGlobal('window', undefined);
-        expect(checkIfStacksProviderIsInstalled('xverse')).toBe(true);
+        expect(checkIfStacksProviderIsInstalled('xverse')).toBe(false);
+        expect(checkIfStacksProviderIsInstalled('leather')).toBe(false);
+        expect(checkIfStacksProviderIsInstalled('asigna')).toBe(false);
+        expect(checkIfStacksProviderIsInstalled('okx')).toBe(false);
+        expect(checkIfStacksProviderIsInstalled('fordefi')).toBe(false);
+    });
+
+    it('returns true for wallet-connect when window is undefined (SSR)', () => {
+        vi.stubGlobal('window', undefined);
+        expect(checkIfStacksProviderIsInstalled('wallet-connect')).toBe(true);
     });
 
     it('detects xverse via XverseProviders', () => {


### PR DESCRIPTION
## Summary
- Fixes #25
- Changes `checkIfStacksProviderIsInstalled` SSR fallback from `return true` to `return wallet === 'wallet-connect'`
- Only wallet-connect returns true during SSR since it doesn't require a browser extension
- Prevents React hydration mismatch between server and client renders

## Test plan
- [x] Updated SSR tests to verify extension wallets return `false` and wallet-connect returns `true`
- [x] All 66 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)