### PR TITLE
fix: memoize onAddressChange to prevent Xverse setup re-runs

### DIFF
--- a/.changeset/fix-memoize-address-change.md
+++ b/.changeset/fix-memoize-address-change.md
@@ -1,0 +1,5 @@
+---
+'@satoshai/kit': patch
+---
+
+Memoize onAddressChange callback to prevent Xverse setup effect from re-running on every render

--- a/packages/kit/src/provider/stacks-wallet-provider.tsx
+++ b/packages/kit/src/provider/stacks-wallet-provider.tsx
@@ -272,13 +272,18 @@ export const StacksWalletProvider = ({
         onConnect(provider, address);
     }, [address, provider, onConnect]);
 
-    useXverse({
-        address,
-        provider,
-        onAddressChange: (newAddress: string) => {
+    const handleAddressChange = useCallback(
+        (newAddress: string) => {
             setAddress(newAddress);
             onAddressChange?.(newAddress);
         },
+        [onAddressChange]
+    );
+
+    useXverse({
+        address,
+        provider,
+        onAddressChange: handleAddressChange,
         connect,
     });
 


### PR DESCRIPTION
## Summary
- Fixes #22
- Wraps the inline `onAddressChange` callback in `useCallback` before passing to `useXverse`
- Prevents the Xverse setup effect from tearing down and re-running on every parent render

## Test plan
- [x] All 65 tests pass
- [x] Lint + typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)