### PR TITLE
fix: move wallet-connect validation to render body for error boundaries

### DIFF
--- a/.changeset/fix-error-boundary-validation.md
+++ b/.changeset/fix-error-boundary-validation.md
@@ -1,0 +1,5 @@
+---
+'@satoshai/kit': patch
+---
+
+Move wallet-connect projectId validation from useEffect to render body so it can be caught by React error boundaries

--- a/packages/kit/src/provider/stacks-wallet-provider.tsx
+++ b/packages/kit/src/provider/stacks-wallet-provider.tsx
@@ -69,14 +69,12 @@ export const StacksWalletProvider = ({
     // invalidate memos on every render. (Fixes #5)
     const walletsKey = wallets?.join(',');
 
-    // Fix #1: runtime guard in useEffect instead of render body
-    useEffect(() => {
-        if (wallets?.includes('wallet-connect') && !walletConnect?.projectId) {
-            throw new Error(
-                'StacksWalletProvider: "wallet-connect" is listed in wallets but no walletConnect.projectId was provided.'
-            );
-        }
-    }, [walletsKey, walletConnect?.projectId]);
+    // Validate in render body so React error boundaries can catch it (#21)
+    if (wallets?.includes('wallet-connect') && !walletConnect?.projectId) {
+        throw new Error(
+            'StacksWalletProvider: "wallet-connect" is listed in wallets but no walletConnect.projectId was provided.'
+        );
+    }
 
     useEffect(() => {
         const loadPersistedWallet = async () => {


### PR DESCRIPTION
## Summary
- Fixes #21
- Moves the wallet-connect `projectId` validation from `useEffect` to the component render body
- Errors thrown in `useEffect` bypass React error boundaries; throwing during render allows consumers to catch with error boundaries

## Test plan
- [x] All 65 tests pass
- [x] Lint + typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)