### PR TITLE
test: full hook test coverage

### DIFF
--- a/.changeset/hook-test-coverage.md
+++ b/.changeset/hook-test-coverage.md
@@ -1,0 +1,5 @@
+---
+'@satoshai/kit': patch
+---
+
+Add comprehensive test coverage for all hooks: useAddress, useWallets, useBnsName, useSignMessage (OKX + publicKey), useWriteContract (standard + OKX), and useXverse

--- a/packages/kit/tests/unit/hooks/use-address.test.ts
+++ b/packages/kit/tests/unit/hooks/use-address.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment happy-dom
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { WalletContextValue } from '../../../src/provider/stacks-wallet-provider.types';
+
+const mockContext: WalletContextValue = {
+    status: 'disconnected',
+    address: undefined,
+    provider: undefined,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    reset: vi.fn(),
+    wallets: [],
+};
+
+vi.mock('../../../src/provider/stacks-wallet-provider', () => ({
+    useStacksWalletContext: () => mockContext,
+}));
+
+const { useAddress } = await import('../../../src/hooks/use-address');
+
+beforeEach(() => {
+    mockContext.status = 'disconnected';
+    mockContext.address = undefined;
+    mockContext.provider = undefined;
+});
+
+describe('useAddress', () => {
+    it('returns disconnected state when status is disconnected', () => {
+        const { result } = renderHook(() => useAddress());
+
+        expect(result.current.isConnected).toBe(false);
+        expect(result.current.isDisconnected).toBe(true);
+        expect(result.current.isConnecting).toBe(false);
+        expect(result.current.address).toBeUndefined();
+        expect(result.current.provider).toBeUndefined();
+    });
+
+    it('returns connecting state when status is connecting', () => {
+        mockContext.status = 'connecting';
+
+        const { result } = renderHook(() => useAddress());
+
+        expect(result.current.isConnected).toBe(false);
+        expect(result.current.isConnecting).toBe(true);
+        expect(result.current.isDisconnected).toBe(false);
+        expect(result.current.address).toBeUndefined();
+        expect(result.current.provider).toBeUndefined();
+    });
+
+    it('returns connected state with address and provider', () => {
+        mockContext.status = 'connected';
+        mockContext.address = 'SP123' as string;
+        mockContext.provider = 'xverse';
+
+        const { result } = renderHook(() => useAddress());
+
+        expect(result.current.isConnected).toBe(true);
+        expect(result.current.isConnecting).toBe(false);
+        expect(result.current.isDisconnected).toBe(false);
+        expect(result.current.address).toBe('SP123');
+        expect(result.current.provider).toBe('xverse');
+    });
+
+    it('falls back to not-connected when status is connected but address is missing', () => {
+        mockContext.status = 'connected';
+        mockContext.address = undefined as unknown as string;
+        mockContext.provider = 'xverse';
+
+        const { result } = renderHook(() => useAddress());
+
+        expect(result.current.isConnected).toBe(false);
+    });
+
+    it('falls back to not-connected when status is connected but provider is missing', () => {
+        mockContext.status = 'connected';
+        mockContext.address = 'SP123' as string;
+        mockContext.provider = undefined as unknown as 'xverse';
+
+        const { result } = renderHook(() => useAddress());
+
+        expect(result.current.isConnected).toBe(false);
+    });
+});

--- a/packages/kit/tests/unit/hooks/use-bns-name.test.ts
+++ b/packages/kit/tests/unit/hooks/use-bns-name.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment happy-dom
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetPrimaryName = vi.fn();
+vi.mock('bns-v2-sdk', () => ({
+    getPrimaryName: mockGetPrimaryName,
+}));
+
+vi.mock('../../../src/utils/get-network-from-address', () => ({
+    getNetworkFromAddress: () => 'mainnet',
+}));
+
+const { useBnsName } = await import('../../../src/hooks/use-bns-name');
+
+beforeEach(() => {
+    mockGetPrimaryName.mockReset();
+});
+
+describe('useBnsName', () => {
+    it('returns null and not loading when no address provided', () => {
+        const { result } = renderHook(() => useBnsName());
+
+        expect(result.current.bnsName).toBeNull();
+        expect(result.current.isLoading).toBe(false);
+    });
+
+    it('resolves BNS name in name.namespace format', async () => {
+        mockGetPrimaryName.mockResolvedValue({
+            name: 'alice',
+            namespace: 'btc',
+        });
+
+        const { result } = renderHook(() => useBnsName('SP123'));
+
+        await waitFor(() => {
+            expect(result.current.bnsName).toBe('alice.btc');
+        });
+
+        expect(result.current.isLoading).toBe(false);
+    });
+
+    it('returns null when getPrimaryName returns null', async () => {
+        mockGetPrimaryName.mockResolvedValue(null);
+
+        const { result } = renderHook(() => useBnsName('SP123'));
+
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(false);
+        });
+
+        expect(result.current.bnsName).toBeNull();
+    });
+
+    it('swallows errors and returns null', async () => {
+        mockGetPrimaryName.mockRejectedValue(new Error('Network error'));
+
+        const { result } = renderHook(() => useBnsName('SP123'));
+
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(false);
+        });
+
+        expect(result.current.bnsName).toBeNull();
+    });
+
+    it('shows loading state while fetching', async () => {
+        let resolveFn!: (value: unknown) => void;
+        mockGetPrimaryName.mockReturnValue(
+            new Promise((resolve) => {
+                resolveFn = resolve;
+            })
+        );
+
+        const { result } = renderHook(() => useBnsName('SP123'));
+
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(true);
+        });
+
+        resolveFn({ name: 'alice', namespace: 'btc' });
+
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(false);
+        });
+
+        expect(result.current.bnsName).toBe('alice.btc');
+    });
+
+    it('refetches when address changes', async () => {
+        mockGetPrimaryName.mockResolvedValue({
+            name: 'alice',
+            namespace: 'btc',
+        });
+
+        const { result, rerender } = renderHook(
+            ({ address }) => useBnsName(address),
+            { initialProps: { address: 'SP123' } }
+        );
+
+        await waitFor(() => {
+            expect(result.current.bnsName).toBe('alice.btc');
+        });
+
+        mockGetPrimaryName.mockResolvedValue({
+            name: 'bob',
+            namespace: 'stx',
+        });
+
+        rerender({ address: 'SP456' });
+
+        await waitFor(() => {
+            expect(result.current.bnsName).toBe('bob.stx');
+        });
+
+        expect(mockGetPrimaryName).toHaveBeenCalledTimes(2);
+    });
+
+    it('ignores stale fetch when address changes mid-flight', async () => {
+        let resolveFirst!: (value: unknown) => void;
+        mockGetPrimaryName.mockReturnValue(
+            new Promise((resolve) => {
+                resolveFirst = resolve;
+            })
+        );
+
+        const { result, rerender } = renderHook(
+            ({ address }) => useBnsName(address),
+            { initialProps: { address: 'SP123' } }
+        );
+
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(true);
+        });
+
+        // Change address before first fetch resolves
+        mockGetPrimaryName.mockResolvedValue({
+            name: 'bob',
+            namespace: 'stx',
+        });
+        rerender({ address: 'SP456' });
+
+        await waitFor(() => {
+            expect(result.current.bnsName).toBe('bob.stx');
+        });
+
+        // Resolve stale first fetch — should be ignored
+        resolveFirst({ name: 'alice', namespace: 'btc' });
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(false);
+        });
+
+        expect(result.current.bnsName).toBe('bob.stx');
+    });
+
+    it('resets to null when address is cleared', async () => {
+        mockGetPrimaryName.mockResolvedValue({
+            name: 'alice',
+            namespace: 'btc',
+        });
+
+        const { result, rerender } = renderHook(
+            ({ address }) => useBnsName(address),
+            { initialProps: { address: 'SP123' as string | undefined } }
+        );
+
+        await waitFor(() => {
+            expect(result.current.bnsName).toBe('alice.btc');
+        });
+
+        rerender({ address: undefined });
+
+        expect(result.current.bnsName).toBeNull();
+        expect(result.current.isLoading).toBe(false);
+    });
+});

--- a/packages/kit/tests/unit/hooks/use-sign-message-okx.test.ts
+++ b/packages/kit/tests/unit/hooks/use-sign-message-okx.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment happy-dom
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../src/hooks/use-address', () => ({
+    useAddress: () => ({
+        isConnected: true,
+        provider: 'okx',
+        address: 'SP123',
+    }),
+}));
+
+const { useSignMessage } = await import(
+    '../../../src/hooks/use-sign-message'
+);
+
+const mockOkxSignMessage = vi.fn();
+
+beforeEach(() => {
+    mockOkxSignMessage.mockReset();
+    vi.stubGlobal('window', {
+        ...window,
+        okxwallet: { stacks: { signMessage: mockOkxSignMessage } },
+    });
+});
+
+describe('useSignMessage (OKX)', () => {
+    it('calls OKX signMessage with message', async () => {
+        const mockResult = { publicKey: 'pk123', signature: 'sig123' };
+        mockOkxSignMessage.mockResolvedValue(mockResult);
+
+        const { result } = renderHook(() => useSignMessage());
+
+        await act(async () => {
+            await result.current.signMessageAsync({ message: 'hello' });
+        });
+
+        expect(mockOkxSignMessage).toHaveBeenCalledWith({ message: 'hello' });
+        expect(result.current.data).toEqual(mockResult);
+        expect(result.current.isSuccess).toBe(true);
+    });
+
+    it('throws when OKX wallet is not found', async () => {
+        vi.stubGlobal('window', {
+            ...window,
+            okxwallet: undefined,
+        });
+
+        const { result } = renderHook(() => useSignMessage());
+
+        await act(async () => {
+            await expect(
+                result.current.signMessageAsync({ message: 'hello' })
+            ).rejects.toThrow('OKX wallet not found');
+        });
+
+        expect(result.current.isError).toBe(true);
+        expect(result.current.error?.message).toBe('OKX wallet not found');
+    });
+
+    it('transitions through pending to success', async () => {
+        let resolveFn!: (value: unknown) => void;
+        mockOkxSignMessage.mockReturnValue(
+            new Promise((resolve) => {
+                resolveFn = resolve;
+            })
+        );
+
+        const { result } = renderHook(() => useSignMessage());
+
+        act(() => {
+            void result.current.signMessageAsync({ message: 'hello' });
+        });
+
+        expect(result.current.isPending).toBe(true);
+
+        await act(async () => {
+            resolveFn({ publicKey: 'pk123', signature: 'sig123' });
+        });
+
+        expect(result.current.isSuccess).toBe(true);
+    });
+
+    it('handles OKX signMessage rejection', async () => {
+        mockOkxSignMessage.mockRejectedValue(new Error('User cancelled'));
+
+        const { result } = renderHook(() => useSignMessage());
+
+        await act(async () => {
+            await expect(
+                result.current.signMessageAsync({ message: 'hello' })
+            ).rejects.toThrow('User cancelled');
+        });
+
+        expect(result.current.isError).toBe(true);
+        expect(result.current.error?.message).toBe('User cancelled');
+    });
+});

--- a/packages/kit/tests/unit/hooks/use-sign-message.test.ts
+++ b/packages/kit/tests/unit/hooks/use-sign-message.test.ts
@@ -149,6 +149,40 @@ describe('useSignMessage', () => {
         expect(result.current.error).toBeNull();
     });
 
+    it('forwards publicKey to request when provided', async () => {
+        const mockResult = { publicKey: 'pk123', signature: 'sig123' };
+        mockRequest.mockResolvedValue(mockResult);
+
+        const { result } = renderHook(() => useSignMessage());
+
+        await act(async () => {
+            await result.current.signMessageAsync({
+                message: 'hello',
+                publicKey: 'my-pub-key',
+            });
+        });
+
+        expect(mockRequest).toHaveBeenCalledWith('stx_signMessage', {
+            message: 'hello',
+            publicKey: 'my-pub-key',
+        });
+    });
+
+    it('omits publicKey from request when not provided', async () => {
+        const mockResult = { publicKey: 'pk123', signature: 'sig123' };
+        mockRequest.mockResolvedValue(mockResult);
+
+        const { result } = renderHook(() => useSignMessage());
+
+        await act(async () => {
+            await result.current.signMessageAsync({ message: 'hello' });
+        });
+
+        expect(mockRequest).toHaveBeenCalledWith('stx_signMessage', {
+            message: 'hello',
+        });
+    });
+
     it('clears previous error on new call', async () => {
         mockRequest.mockRejectedValue(new Error('First failure'));
 

--- a/packages/kit/tests/unit/hooks/use-wallets.test.ts
+++ b/packages/kit/tests/unit/hooks/use-wallets.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment happy-dom
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type {
+    WalletContextValue,
+    WalletInfo,
+} from '../../../src/provider/stacks-wallet-provider.types';
+
+const mockContext: WalletContextValue = {
+    status: 'disconnected',
+    address: undefined,
+    provider: undefined,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    reset: vi.fn(),
+    wallets: [],
+};
+
+vi.mock('../../../src/provider/stacks-wallet-provider', () => ({
+    useStacksWalletContext: () => mockContext,
+}));
+
+const { useWallets } = await import('../../../src/hooks/use-wallets');
+
+beforeEach(() => {
+    mockContext.wallets = [];
+});
+
+describe('useWallets', () => {
+    it('returns wallets from context', () => {
+        const wallets: WalletInfo[] = [
+            {
+                id: 'xverse',
+                name: 'Xverse',
+                icon: 'xverse.png',
+                webUrl: 'https://xverse.app',
+                available: true,
+            },
+            {
+                id: 'leather',
+                name: 'Leather',
+                icon: 'leather.png',
+                webUrl: 'https://leather.io',
+                available: false,
+            },
+        ];
+        mockContext.wallets = wallets;
+
+        const { result } = renderHook(() => useWallets());
+
+        expect(result.current.wallets).toBe(wallets);
+        expect(result.current.wallets).toHaveLength(2);
+    });
+
+    it('returns empty array when no wallets available', () => {
+        const { result } = renderHook(() => useWallets());
+
+        expect(result.current.wallets).toEqual([]);
+    });
+
+    it('returns same reference on rerender when wallets unchanged', () => {
+        const wallets: WalletInfo[] = [
+            {
+                id: 'xverse',
+                name: 'Xverse',
+                icon: 'xverse.png',
+                webUrl: 'https://xverse.app',
+                available: true,
+            },
+        ];
+        mockContext.wallets = wallets;
+
+        const { result, rerender } = renderHook(() => useWallets());
+        const first = result.current;
+
+        rerender();
+
+        expect(result.current).toBe(first);
+    });
+});

--- a/packages/kit/tests/unit/hooks/use-write-contract-okx.test.ts
+++ b/packages/kit/tests/unit/hooks/use-write-contract-okx.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment happy-dom
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@stacks/transactions', () => ({
+    PostConditionMode: { Allow: 1, Deny: 2 },
+}));
+
+vi.mock('../../../src/hooks/use-address', () => ({
+    useAddress: () => ({
+        isConnected: true,
+        address: 'SP123',
+        provider: 'okx',
+    }),
+}));
+
+vi.mock('../../../src/utils/get-network-from-address', () => ({
+    getNetworkFromAddress: () => 'mainnet',
+}));
+
+vi.mock(
+    '../../../src/hooks/use-write-contract/use-write-contract.helpers',
+    () => ({
+        prepareArgsForOKX: vi.fn((args: unknown[]) => args),
+        preparePostConditionsForOKX: vi.fn((pcs: unknown[]) => pcs),
+    })
+);
+
+const { useWriteContract } = await import(
+    '../../../src/hooks/use-write-contract/use-write-contract'
+);
+
+const mockOkxSignTransaction = vi.fn();
+
+const baseVariables = {
+    address: 'SP1CONTRACT',
+    contract: 'my-contract',
+    functionName: 'transfer',
+    args: [],
+    pc: { postConditions: [], mode: 2 },
+};
+
+beforeEach(() => {
+    mockOkxSignTransaction.mockReset();
+    vi.stubGlobal('window', {
+        ...window,
+        okxwallet: { stacks: { signTransaction: mockOkxSignTransaction } },
+    });
+});
+
+describe('useWriteContract (OKX)', () => {
+    it('calls OKX signTransaction and returns txHash', async () => {
+        mockOkxSignTransaction.mockResolvedValue({ txHash: '0xokx123' });
+
+        const { result } = renderHook(() => useWriteContract());
+
+        let txHash: string | undefined;
+        await act(async () => {
+            txHash = await result.current.writeContractAsync(baseVariables);
+        });
+
+        expect(txHash).toBe('0xokx123');
+        expect(result.current.data).toBe('0xokx123');
+        expect(result.current.isSuccess).toBe(true);
+    });
+
+    it('throws when OKX wallet is not found', async () => {
+        vi.stubGlobal('window', {
+            ...window,
+            okxwallet: undefined,
+        });
+
+        const { result } = renderHook(() => useWriteContract());
+
+        await act(async () => {
+            await expect(
+                result.current.writeContractAsync(baseVariables)
+            ).rejects.toThrow('OKX wallet not found');
+        });
+
+        expect(result.current.isError).toBe(true);
+        expect(result.current.error?.message).toBe('OKX wallet not found');
+    });
+
+    it('passes correct params to OKX signTransaction', async () => {
+        mockOkxSignTransaction.mockResolvedValue({ txHash: '0xokx123' });
+
+        const { result } = renderHook(() => useWriteContract());
+
+        await act(async () => {
+            await result.current.writeContractAsync(baseVariables);
+        });
+
+        expect(mockOkxSignTransaction).toHaveBeenCalledWith({
+            contractAddress: 'SP1CONTRACT',
+            contractName: 'my-contract',
+            functionName: 'transfer',
+            functionArgs: [],
+            postConditions: [],
+            postConditionMode: 2,
+            stxAddress: 'SP123',
+            txType: 'contract_call',
+            anchorMode: 3,
+        });
+    });
+
+    it('transitions through pending to success', async () => {
+        let resolveFn!: (value: unknown) => void;
+        mockOkxSignTransaction.mockReturnValue(
+            new Promise((resolve) => {
+                resolveFn = resolve;
+            })
+        );
+
+        const { result } = renderHook(() => useWriteContract());
+
+        act(() => {
+            void result.current.writeContractAsync(baseVariables);
+        });
+
+        expect(result.current.isPending).toBe(true);
+
+        await act(async () => {
+            resolveFn({ txHash: '0xokx123' });
+        });
+
+        expect(result.current.isSuccess).toBe(true);
+        expect(result.current.data).toBe('0xokx123');
+    });
+});

--- a/packages/kit/tests/unit/hooks/use-write-contract.test.ts
+++ b/packages/kit/tests/unit/hooks/use-write-contract.test.ts
@@ -1,0 +1,267 @@
+// @vitest-environment happy-dom
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockRequest = vi.fn();
+vi.mock('@stacks/connect', () => ({
+    request: mockRequest,
+}));
+
+vi.mock('@stacks/transactions', () => ({
+    PostConditionMode: { Allow: 1, Deny: 2 },
+}));
+
+vi.mock('../../../src/hooks/use-address', () => ({
+    useAddress: () => ({
+        isConnected: true,
+        address: 'SP123',
+        provider: 'leather',
+    }),
+}));
+
+vi.mock('../../../src/utils/get-network-from-address', () => ({
+    getNetworkFromAddress: () => 'mainnet',
+}));
+
+vi.mock(
+    '../../../src/hooks/use-write-contract/use-write-contract.helpers',
+    () => ({
+        prepareArgsForOKX: vi.fn((args: unknown[]) => args),
+        preparePostConditionsForOKX: vi.fn((pcs: unknown[]) => pcs),
+    })
+);
+
+const { useWriteContract } = await import(
+    '../../../src/hooks/use-write-contract/use-write-contract'
+);
+
+const baseVariables = {
+    address: 'SP1CONTRACT',
+    contract: 'my-contract',
+    functionName: 'transfer',
+    args: [],
+    pc: { postConditions: [], mode: 2 }, // Deny
+};
+
+beforeEach(() => {
+    mockRequest.mockReset();
+});
+
+describe('useWriteContract', () => {
+    it('returns idle state initially', () => {
+        const { result } = renderHook(() => useWriteContract());
+
+        expect(result.current.status).toBe('idle');
+        expect(result.current.isIdle).toBe(true);
+        expect(result.current.isPending).toBe(false);
+        expect(result.current.isSuccess).toBe(false);
+        expect(result.current.isError).toBe(false);
+        expect(result.current.error).toBeNull();
+        expect(result.current.data).toBeUndefined();
+    });
+
+    it('transitions to success with txid', async () => {
+        mockRequest.mockResolvedValue({ txid: '0xabc123' });
+
+        const { result } = renderHook(() => useWriteContract());
+
+        await act(async () => {
+            await result.current.writeContractAsync(baseVariables);
+        });
+
+        expect(result.current.status).toBe('success');
+        expect(result.current.isSuccess).toBe(true);
+        expect(result.current.data).toBe('0xabc123');
+        expect(result.current.error).toBeNull();
+    });
+
+    it('formats contract as address.contract', async () => {
+        mockRequest.mockResolvedValue({ txid: '0xabc123' });
+
+        const { result } = renderHook(() => useWriteContract());
+
+        await act(async () => {
+            await result.current.writeContractAsync(baseVariables);
+        });
+
+        expect(mockRequest).toHaveBeenCalledWith(
+            'stx_callContract',
+            expect.objectContaining({
+                contract: 'SP1CONTRACT.my-contract',
+            })
+        );
+    });
+
+    it('maps PostConditionMode.Allow to allow string', async () => {
+        mockRequest.mockResolvedValue({ txid: '0xabc123' });
+
+        const { result } = renderHook(() => useWriteContract());
+
+        await act(async () => {
+            await result.current.writeContractAsync({
+                ...baseVariables,
+                pc: { postConditions: [], mode: 1 }, // Allow
+            });
+        });
+
+        expect(mockRequest).toHaveBeenCalledWith(
+            'stx_callContract',
+            expect.objectContaining({
+                postConditionMode: 'allow',
+            })
+        );
+    });
+
+    it('maps PostConditionMode.Deny to deny string', async () => {
+        mockRequest.mockResolvedValue({ txid: '0xabc123' });
+
+        const { result } = renderHook(() => useWriteContract());
+
+        await act(async () => {
+            await result.current.writeContractAsync(baseVariables);
+        });
+
+        expect(mockRequest).toHaveBeenCalledWith(
+            'stx_callContract',
+            expect.objectContaining({
+                postConditionMode: 'deny',
+            })
+        );
+    });
+
+    it('passes network from getNetworkFromAddress', async () => {
+        mockRequest.mockResolvedValue({ txid: '0xabc123' });
+
+        const { result } = renderHook(() => useWriteContract());
+
+        await act(async () => {
+            await result.current.writeContractAsync(baseVariables);
+        });
+
+        expect(mockRequest).toHaveBeenCalledWith(
+            'stx_callContract',
+            expect.objectContaining({
+                network: 'mainnet',
+            })
+        );
+    });
+
+    it('throws when response has no txid', async () => {
+        mockRequest.mockResolvedValue({});
+
+        const { result } = renderHook(() => useWriteContract());
+
+        await act(async () => {
+            await expect(
+                result.current.writeContractAsync(baseVariables)
+            ).rejects.toThrow('No transaction ID returned');
+        });
+
+        expect(result.current.isError).toBe(true);
+        expect(result.current.error?.message).toBe(
+            'No transaction ID returned'
+        );
+    });
+
+    it('transitions to error on failure', async () => {
+        mockRequest.mockRejectedValue(new Error('User rejected'));
+
+        const { result } = renderHook(() => useWriteContract());
+
+        await act(async () => {
+            await expect(
+                result.current.writeContractAsync(baseVariables)
+            ).rejects.toThrow('User rejected');
+        });
+
+        expect(result.current.status).toBe('error');
+        expect(result.current.isError).toBe(true);
+        expect(result.current.error?.message).toBe('User rejected');
+        expect(result.current.data).toBeUndefined();
+    });
+
+    it('calls onSuccess and onSettled callbacks via writeContract', async () => {
+        mockRequest.mockResolvedValue({ txid: '0xabc123' });
+
+        const onSuccess = vi.fn();
+        const onSettled = vi.fn();
+
+        const { result } = renderHook(() => useWriteContract());
+
+        await act(async () => {
+            result.current.writeContract(baseVariables, {
+                onSuccess,
+                onSettled,
+            });
+            await new Promise((r) => setTimeout(r, 0));
+        });
+
+        expect(onSuccess).toHaveBeenCalledWith('0xabc123');
+        expect(onSettled).toHaveBeenCalledWith('0xabc123', null);
+    });
+
+    it('calls onError and onSettled callbacks on failure via writeContract', async () => {
+        mockRequest.mockRejectedValue(new Error('Rejected'));
+
+        const onError = vi.fn();
+        const onSettled = vi.fn();
+
+        const { result } = renderHook(() => useWriteContract());
+
+        await act(async () => {
+            result.current.writeContract(baseVariables, {
+                onError,
+                onSettled,
+            });
+            await new Promise((r) => setTimeout(r, 0));
+        });
+
+        expect(onError).toHaveBeenCalledWith(expect.any(Error));
+        expect(onSettled).toHaveBeenCalledWith(undefined, expect.any(Error));
+    });
+
+    it('reset clears data, error, and status', async () => {
+        mockRequest.mockResolvedValue({ txid: '0xabc123' });
+
+        const { result } = renderHook(() => useWriteContract());
+
+        await act(async () => {
+            await result.current.writeContractAsync(baseVariables);
+        });
+
+        expect(result.current.data).toBe('0xabc123');
+
+        act(() => {
+            result.current.reset();
+        });
+
+        expect(result.current.status).toBe('idle');
+        expect(result.current.isIdle).toBe(true);
+        expect(result.current.data).toBeUndefined();
+        expect(result.current.error).toBeNull();
+    });
+
+    it('clears previous error on new call', async () => {
+        mockRequest.mockRejectedValue(new Error('First failure'));
+
+        const { result } = renderHook(() => useWriteContract());
+
+        await act(async () => {
+            await expect(
+                result.current.writeContractAsync(baseVariables)
+            ).rejects.toThrow();
+        });
+
+        expect(result.current.isError).toBe(true);
+
+        mockRequest.mockResolvedValue({ txid: '0xabc123' });
+
+        await act(async () => {
+            await result.current.writeContractAsync(baseVariables);
+        });
+
+        expect(result.current.isSuccess).toBe(true);
+        expect(result.current.error).toBeNull();
+        expect(result.current.data).toBe('0xabc123');
+    });
+});

--- a/packages/kit/tests/unit/hooks/use-xverse.test.ts
+++ b/packages/kit/tests/unit/hooks/use-xverse.test.ts
@@ -1,0 +1,402 @@
+// @vitest-environment happy-dom
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetSelectedProvider = vi.fn();
+vi.mock('@stacks/connect', () => ({
+    getSelectedProvider: mockGetSelectedProvider,
+}));
+
+const mockWaitForXverseProvider = vi.fn();
+const mockGetXverseProductInfo = vi.fn();
+const mockShouldSupportAccountChange = vi.fn();
+const mockExtractAndValidateStacksAddress = vi.fn();
+
+vi.mock('../../../src/hooks/use-xverse/use-xverse.helpers', () => ({
+    waitForXverseProvider: mockWaitForXverseProvider,
+    getXverseProductInfo: mockGetXverseProductInfo,
+    shouldSupportAccountChange: mockShouldSupportAccountChange,
+    extractAndValidateStacksAddress: mockExtractAndValidateStacksAddress,
+}));
+
+const { useXverse } = await import(
+    '../../../src/hooks/use-xverse/use-xverse'
+);
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+    mockGetSelectedProvider.mockReset();
+    mockWaitForXverseProvider.mockReset();
+    mockGetXverseProductInfo.mockReset();
+    mockShouldSupportAccountChange.mockReset();
+    mockExtractAndValidateStacksAddress.mockReset();
+});
+
+describe('useXverse', () => {
+    describe('non-xverse provider', () => {
+        it('does not run effects when provider is not xverse', () => {
+            renderHook(() =>
+                useXverse({
+                    address: 'SP123',
+                    provider: 'leather',
+                    onAddressChange: vi.fn(),
+                    connect: vi.fn(),
+                })
+            );
+
+            expect(mockWaitForXverseProvider).not.toHaveBeenCalled();
+        });
+
+        it('does not run effects when provider is undefined', () => {
+            renderHook(() =>
+                useXverse({
+                    address: undefined,
+                    provider: undefined,
+                    onAddressChange: vi.fn(),
+                    connect: vi.fn(),
+                })
+            );
+
+            expect(mockWaitForXverseProvider).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('provider readiness', () => {
+        it('calls waitForXverseProvider when provider is xverse', async () => {
+            mockWaitForXverseProvider.mockResolvedValue(true);
+            mockGetXverseProductInfo.mockResolvedValue({ version: '2.0.0' });
+            mockShouldSupportAccountChange.mockReturnValue(true);
+            mockGetSelectedProvider.mockReturnValue({
+                request: vi.fn().mockResolvedValue({ result: { addresses: [] } }),
+                addListener: vi.fn().mockReturnValue(vi.fn()),
+            });
+
+            await act(async () => {
+                renderHook(() =>
+                    useXverse({
+                        address: 'SP123',
+                        provider: 'xverse',
+                        onAddressChange: vi.fn(),
+                        connect: vi.fn(),
+                    })
+                );
+                await flushPromises();
+            });
+
+            expect(mockWaitForXverseProvider).toHaveBeenCalled();
+        });
+
+        it('logs error when provider fails to initialize', async () => {
+            mockWaitForXverseProvider.mockResolvedValue(false);
+            const consoleSpy = vi
+                .spyOn(console, 'error')
+                .mockImplementation(() => {});
+
+            await act(async () => {
+                renderHook(() =>
+                    useXverse({
+                        address: 'SP123',
+                        provider: 'xverse',
+                        onAddressChange: vi.fn(),
+                        connect: vi.fn(),
+                    })
+                );
+                await flushPromises();
+            });
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                'Xverse provider failed to initialize'
+            );
+            consoleSpy.mockRestore();
+        });
+    });
+
+    describe('listener setup', () => {
+        it('skips setup when shouldSupportAccountChange returns false', async () => {
+            mockWaitForXverseProvider.mockResolvedValue(true);
+            mockGetXverseProductInfo.mockResolvedValue({ version: '1.0.0' });
+            mockShouldSupportAccountChange.mockReturnValue(false);
+
+            await act(async () => {
+                renderHook(() =>
+                    useXverse({
+                        address: 'SP123',
+                        provider: 'xverse',
+                        onAddressChange: vi.fn(),
+                        connect: vi.fn(),
+                    })
+                );
+                await flushPromises();
+            });
+
+            expect(mockShouldSupportAccountChange).toHaveBeenCalledWith(
+                '1.0.0'
+            );
+            expect(mockGetSelectedProvider).not.toHaveBeenCalled();
+        });
+
+        it('calls wallet_connect and addListener on setup', async () => {
+            mockWaitForXverseProvider.mockResolvedValue(true);
+            mockGetXverseProductInfo.mockResolvedValue({ version: '2.0.0' });
+            mockShouldSupportAccountChange.mockReturnValue(true);
+
+            const mockProviderRequest = vi
+                .fn()
+                .mockResolvedValue({ result: { addresses: [] } });
+            const mockAddListener = vi.fn().mockReturnValue(vi.fn());
+            mockGetSelectedProvider.mockReturnValue({
+                request: mockProviderRequest,
+                addListener: mockAddListener,
+            });
+
+            await act(async () => {
+                renderHook(() =>
+                    useXverse({
+                        address: 'SP123',
+                        provider: 'xverse',
+                        onAddressChange: vi.fn(),
+                        connect: vi.fn(),
+                    })
+                );
+                await flushPromises();
+            });
+
+            expect(mockProviderRequest).toHaveBeenCalledWith(
+                'wallet_connect',
+                null
+            );
+            expect(mockAddListener).toHaveBeenCalledWith(
+                'accountChange',
+                expect.any(Function)
+            );
+        });
+
+        it('calls extractAndValidateStacksAddress with wallet_connect response', async () => {
+            mockWaitForXverseProvider.mockResolvedValue(true);
+            mockGetXverseProductInfo.mockResolvedValue({ version: '2.0.0' });
+            mockShouldSupportAccountChange.mockReturnValue(true);
+
+            const mockAddresses = [
+                {
+                    address: 'SP456',
+                    publicKey: 'pk',
+                    purpose: 'stacks',
+                    addressType: 'stacks',
+                    walletType: 'software',
+                },
+            ];
+            const mockProviderRequest = vi.fn().mockResolvedValue({
+                result: { addresses: mockAddresses },
+            });
+            const mockAddListener = vi.fn().mockReturnValue(vi.fn());
+            mockGetSelectedProvider.mockReturnValue({
+                request: mockProviderRequest,
+                addListener: mockAddListener,
+            });
+
+            const onAddressChange = vi.fn();
+
+            await act(async () => {
+                renderHook(() =>
+                    useXverse({
+                        address: 'SP123',
+                        provider: 'xverse',
+                        onAddressChange,
+                        connect: vi.fn(),
+                    })
+                );
+                await flushPromises();
+            });
+
+            expect(
+                mockExtractAndValidateStacksAddress
+            ).toHaveBeenCalledWith(
+                mockAddresses,
+                'SP123',
+                onAddressChange,
+                expect.any(Function)
+            );
+        });
+
+        it('fires extractAndValidateStacksAddress on accountChange event', async () => {
+            mockWaitForXverseProvider.mockResolvedValue(true);
+            mockGetXverseProductInfo.mockResolvedValue({ version: '2.0.0' });
+            mockShouldSupportAccountChange.mockReturnValue(true);
+
+            let capturedHandler!: (event: unknown) => void;
+            const mockAddListener = vi
+                .fn()
+                .mockImplementation((_event: string, handler: (event: unknown) => void) => {
+                    capturedHandler = handler;
+                    return vi.fn();
+                });
+            mockGetSelectedProvider.mockReturnValue({
+                request: vi
+                    .fn()
+                    .mockResolvedValue({ result: { addresses: [] } }),
+                addListener: mockAddListener,
+            });
+
+            const onAddressChange = vi.fn();
+
+            await act(async () => {
+                renderHook(() =>
+                    useXverse({
+                        address: 'SP123',
+                        provider: 'xverse',
+                        onAddressChange,
+                        connect: vi.fn(),
+                    })
+                );
+                await flushPromises();
+            });
+
+            // Reset to only check the accountChange call
+            mockExtractAndValidateStacksAddress.mockReset();
+
+            const accountEvent = {
+                type: 'accountChange',
+                addresses: [
+                    {
+                        address: 'SP789',
+                        publicKey: 'pk',
+                        purpose: 'stacks',
+                        addressType: 'stacks',
+                        walletType: 'software',
+                    },
+                ],
+            };
+
+            act(() => {
+                capturedHandler(accountEvent);
+            });
+
+            expect(
+                mockExtractAndValidateStacksAddress
+            ).toHaveBeenCalledWith(
+                accountEvent.addresses,
+                'SP123',
+                onAddressChange,
+                expect.any(Function)
+            );
+        });
+    });
+
+    describe('cleanup', () => {
+        it('calls removeListener on unmount', async () => {
+            mockWaitForXverseProvider.mockResolvedValue(true);
+            mockGetXverseProductInfo.mockResolvedValue({ version: '2.0.0' });
+            mockShouldSupportAccountChange.mockReturnValue(true);
+
+            const mockRemoveListener = vi.fn();
+            mockGetSelectedProvider.mockReturnValue({
+                request: vi
+                    .fn()
+                    .mockResolvedValue({ result: { addresses: [] } }),
+                addListener: vi.fn().mockReturnValue(mockRemoveListener),
+            });
+
+            let unmount!: () => void;
+            await act(async () => {
+                const hook = renderHook(() =>
+                    useXverse({
+                        address: 'SP123',
+                        provider: 'xverse',
+                        onAddressChange: vi.fn(),
+                        connect: vi.fn(),
+                    })
+                );
+                unmount = hook.unmount;
+                await flushPromises();
+            });
+
+            act(() => {
+                unmount();
+            });
+
+            expect(mockRemoveListener).toHaveBeenCalled();
+        });
+
+        it('logs error when removeListener throws on unmount', async () => {
+            mockWaitForXverseProvider.mockResolvedValue(true);
+            mockGetXverseProductInfo.mockResolvedValue({ version: '2.0.0' });
+            mockShouldSupportAccountChange.mockReturnValue(true);
+
+            const removeError = new Error('Remove failed');
+            mockGetSelectedProvider.mockReturnValue({
+                request: vi
+                    .fn()
+                    .mockResolvedValue({ result: { addresses: [] } }),
+                addListener: vi.fn().mockReturnValue(() => {
+                    throw removeError;
+                }),
+            });
+
+            const consoleSpy = vi
+                .spyOn(console, 'error')
+                .mockImplementation(() => {});
+
+            let unmount!: () => void;
+            await act(async () => {
+                const hook = renderHook(() =>
+                    useXverse({
+                        address: 'SP123',
+                        provider: 'xverse',
+                        onAddressChange: vi.fn(),
+                        connect: vi.fn(),
+                    })
+                );
+                unmount = hook.unmount;
+                await flushPromises();
+            });
+
+            act(() => {
+                unmount();
+            });
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                'Failed to remove Xverse listener:',
+                removeError
+            );
+            consoleSpy.mockRestore();
+        });
+    });
+
+    describe('cancellation', () => {
+        it('does not update state after unmount during first effect', async () => {
+            let resolveWait!: (value: boolean) => void;
+            mockWaitForXverseProvider.mockReturnValue(
+                new Promise((resolve) => {
+                    resolveWait = resolve;
+                })
+            );
+
+            const consoleSpy = vi
+                .spyOn(console, 'error')
+                .mockImplementation(() => {});
+
+            const { unmount } = renderHook(() =>
+                useXverse({
+                    address: 'SP123',
+                    provider: 'xverse',
+                    onAddressChange: vi.fn(),
+                    connect: vi.fn(),
+                })
+            );
+
+            // Unmount before the provider check resolves
+            unmount();
+
+            // Resolve after unmount — should not cause errors
+            await act(async () => {
+                resolveWait(true);
+                await flushPromises();
+            });
+
+            // The second effect should never run since isProviderReady was never set
+            expect(mockGetXverseProductInfo).not.toHaveBeenCalled();
+            consoleSpy.mockRestore();
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive tests for all 6 hooks: useAddress, useWallets, useBnsName, useSignMessage, useWriteContract, useXverse
- 49 new tests across 8 files (7 new + 1 extended), bringing total to 115
- Cover standard paths, OKX wallet paths, edge cases, cancellation, and cleanup

## Test breakdown
| File | Hook | Tests |
|------|------|-------|
| `use-address.test.ts` | useAddress | 5 |
| `use-wallets.test.ts` | useWallets | 3 |
| `use-bns-name.test.ts` | useBnsName | 8 |
| `use-sign-message.test.ts` | useSignMessage (extended) | +2 |
| `use-sign-message-okx.test.ts` | useSignMessage OKX | 4 |
| `use-write-contract.test.ts` | useWriteContract | 12 |
| `use-write-contract-okx.test.ts` | useWriteContract OKX | 4 |
| `use-xverse.test.ts` | useXverse | 11 |

Closes #14

## Test plan
- [x] `pnpm --filter @satoshai/kit test` — 115 tests pass
- [x] Pre-commit hooks (lint + typecheck) pass
- [x] Pre-push hooks (test) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)