### PR TITLE
feat: typed useWriteContract with ABI inference

### DIFF
--- a/.changeset/typed-write-contract.md
+++ b/.changeset/typed-write-contract.md
@@ -1,0 +1,5 @@
+---
+'@satoshai/kit': minor
+---
+
+Add typed `useWriteContract` with ABI inference (#35). Pass a Clarity ABI (`as const`) to get autocomplete on public function names and type-checked named args — no manual `ClarityValue` construction. Omitting `abi` preserves the current untyped API. Includes `createContractConfig` helper for reusable contract bindings and new type utilities (`PublicFunctionName`, `PublicFunctionArgs`, `TraitReference`).

--- a/examples/vite-react/src/app.tsx
+++ b/examples/vite-react/src/app.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { PostConditionMode } from '@stacks/transactions';
 import {
     StacksWalletProvider,
     useAddress,
@@ -6,9 +7,45 @@ import {
     useDisconnect,
     useBnsName,
     useWallets,
+    useWriteContract,
+    createContractConfig,
 } from '@satoshai/kit';
 
 const wcProjectId = import.meta.env.VITE_WALLETCONNECT_PROJECT_ID as string | undefined;
+
+// Sample SIP-010 token ABI (as const for type inference)
+const tokenAbi = {
+    functions: [
+        {
+            name: 'transfer',
+            access: 'public',
+            args: [
+                { name: 'amount', type: 'uint128' },
+                { name: 'sender', type: 'principal' },
+                { name: 'recipient', type: 'principal' },
+                { name: 'memo', type: { optional: { buffer: { length: 34 } } } },
+            ],
+            outputs: { type: { response: { ok: 'bool', error: 'uint128' } } },
+        },
+        {
+            name: 'get-balance',
+            access: 'read_only',
+            args: [{ name: 'who', type: 'principal' }],
+            outputs: { type: { response: { ok: 'uint128', error: 'none' } } },
+        },
+    ],
+    variables: [],
+    maps: [],
+    fungible_tokens: [{ name: 'my-token' }],
+    non_fungible_tokens: [],
+} as const;
+
+// Pre-bind contract config for reuse
+const myToken = createContractConfig({
+    abi: tokenAbi,
+    address: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM',
+    contract: 'my-token',
+});
 
 export const App = () => {
     const [useModal, setUseModal] = useState(true);
@@ -55,6 +92,7 @@ const Wallet = ({ useModal }: { useModal: boolean }) => {
                         <strong>BNS:</strong> {bnsName}
                     </p>
                 ) : null}
+                <WriteContractDemo address={address} />
                 <button onClick={() => disconnect()}>Disconnect</button>
             </div>
         );
@@ -97,6 +135,46 @@ const Wallet = ({ useModal }: { useModal: boolean }) => {
                     </div>
                 ))}
             </div>
+        </div>
+    );
+};
+
+// Demonstrates typed useWriteContract with ABI inference
+const WriteContractDemo = ({ address }: { address: string }) => {
+    const { writeContract, isPending, isSuccess, isError, data, error } = useWriteContract();
+
+    const handleTransfer = () => {
+        // Typed mode: functionName autocompletes, args are type-checked
+        writeContract(
+            {
+                ...myToken,
+                functionName: 'transfer', // autocompletes: 'transfer'
+                args: {
+                    amount: 1000000n,
+                    sender: address,
+                    recipient: 'SP000000000000000000002Q6VF78',
+                    memo: null,
+                },
+                pc: {
+                    postConditions: [],
+                    mode: PostConditionMode.Allow,
+                },
+            },
+            {
+                onSuccess: (txHash) => console.log('TX sent:', txHash),
+                onError: (err) => console.error('TX failed:', err),
+            }
+        );
+    };
+
+    return (
+        <div style={{ marginTop: '1rem', marginBottom: '1rem' }}>
+            <h3>Write Contract (Typed)</h3>
+            <button onClick={handleTransfer} disabled={isPending}>
+                {isPending ? 'Sending...' : 'Transfer 1 STX'}
+            </button>
+            {isSuccess && <p style={{ color: 'green' }}>TX: {data}</p>}
+            {isError && <p style={{ color: 'red' }}>Error: {error?.message}</p>}
         </div>
     );
 };

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -33,7 +33,8 @@
   },
   "dependencies": {
     "@stacks/connect": "8.2.5",
-    "bns-v2-sdk": "^2.1.0"
+    "bns-v2-sdk": "^2.1.0",
+    "clarity-abitype": "^0.4.0"
   },
   "peerDependencies": {
     "@stacks/transactions": ">=7.0.0",

--- a/packages/kit/src/hooks/use-write-contract/use-write-contract.ts
+++ b/packages/kit/src/hooks/use-write-contract/use-write-contract.ts
@@ -1,21 +1,65 @@
 'use client';
 
 import { request } from '@stacks/connect';
+import type { ClarityValue } from '@stacks/transactions';
 import { PostConditionMode } from '@stacks/transactions';
 import { useCallback, useMemo, useState } from 'react';
 
 import type { MutationStatus } from '../../provider/stacks-wallet-provider.types';
 import { useAddress } from '../use-address';
 import { getNetworkFromAddress } from '../../utils/get-network-from-address';
+import { namedArgsToClarityValues } from '../../utils/to-clarity-value';
 
 import {
     preparePostConditionsForOKX,
     prepareArgsForOKX,
 } from './use-write-contract.helpers';
 import type {
-    WriteContractVariables,
+    PostConditionConfig,
     WriteContractOptions,
+    WriteContractAsyncFn,
+    WriteContractFn,
 } from './use-write-contract.types';
+
+/** Loose internal ABI shape for runtime — avoids importing ClarityAbi which triggers deep instantiation. */
+interface AbiLike {
+    functions: readonly {
+        name: string;
+        access: string;
+        args: readonly { name: string; type: unknown }[];
+    }[];
+}
+
+/** Internal variables shape accepted at runtime (both typed and untyped). */
+interface WriteContractVariablesInternal {
+    abi?: AbiLike;
+    address: string;
+    contract: string;
+    functionName: string;
+    args: Record<string, unknown> | ClarityValue[];
+    pc: PostConditionConfig;
+}
+
+/** Resolve args to ClarityValue[]: convert named args when ABI is present. */
+function resolveArgs(variables: WriteContractVariablesInternal): ClarityValue[] {
+    if (!variables.abi) {
+        return variables.args as ClarityValue[];
+    }
+
+    const fn = variables.abi.functions.find(
+        (f) => f.name === variables.functionName && f.access === 'public'
+    );
+    if (!fn) {
+        throw new Error(
+            `@satoshai/kit: Public function "${variables.functionName}" not found in ABI`
+        );
+    }
+
+    return namedArgsToClarityValues(
+        variables.args as Record<string, unknown>,
+        fn.args
+    );
+}
 
 export const useWriteContract = () => {
     const { isConnected, address, provider } = useAddress();
@@ -25,7 +69,7 @@ export const useWriteContract = () => {
     const [status, setStatus] = useState<MutationStatus>('idle');
 
     const writeContractAsync = useCallback(
-        async (variables: WriteContractVariables): Promise<string> => {
+        async (variables: WriteContractVariablesInternal): Promise<string> => {
             if (!isConnected || !address) {
                 throw new Error('Wallet is not connected');
             }
@@ -33,6 +77,8 @@ export const useWriteContract = () => {
             setStatus('pending');
             setError(null);
             setData(undefined);
+
+            const resolvedArgs = resolveArgs(variables);
 
             try {
                 if (provider === 'okx') {
@@ -45,7 +91,7 @@ export const useWriteContract = () => {
                             contractAddress: variables.address,
                             contractName: variables.contract,
                             functionName: variables.functionName,
-                            functionArgs: prepareArgsForOKX(variables.args),
+                            functionArgs: prepareArgsForOKX(resolvedArgs),
                             postConditions: preparePostConditionsForOKX(
                                 variables.pc.postConditions
                             ),
@@ -64,7 +110,7 @@ export const useWriteContract = () => {
                     address,
                     contract: `${variables.address}.${variables.contract}`,
                     functionName: variables.functionName,
-                    functionArgs: variables.args,
+                    functionArgs: resolvedArgs,
                     postConditions: variables.pc.postConditions,
                     postConditionMode:
                         variables.pc.mode === PostConditionMode.Allow
@@ -89,11 +135,11 @@ export const useWriteContract = () => {
             }
         },
         [isConnected, address, provider]
-    );
+    ) as unknown as WriteContractAsyncFn;
 
     const writeContract = useCallback(
-        (variables: WriteContractVariables, options?: WriteContractOptions) => {
-            writeContractAsync(variables)
+        (variables: WriteContractVariablesInternal, options?: WriteContractOptions) => {
+            (writeContractAsync as unknown as (v: WriteContractVariablesInternal) => Promise<string>)(variables)
                 .then((data) => {
                     options?.onSuccess?.(data);
                     options?.onSettled?.(data, null);
@@ -104,7 +150,7 @@ export const useWriteContract = () => {
                 });
         },
         [writeContractAsync]
-    );
+    ) as unknown as WriteContractFn;
 
     const reset = useCallback(() => {
         setData(undefined);
@@ -133,4 +179,8 @@ export type {
     WriteContractVariables,
     WriteContractOptions,
     PostConditionConfig,
+    TypedWriteContractVariables,
+    UntypedWriteContractVariables,
+    WriteContractAsyncFn,
+    WriteContractFn,
 } from './use-write-contract.types';

--- a/packages/kit/src/hooks/use-write-contract/use-write-contract.types.ts
+++ b/packages/kit/src/hooks/use-write-contract/use-write-contract.types.ts
@@ -3,13 +3,33 @@ import type {
     PostCondition,
     PostConditionMode,
 } from '@stacks/transactions';
+import type {
+    ClarityAbi,
+    ExtractAbiFunctionNames,
+} from 'clarity-abitype';
+
+import type { PublicFunctionArgs } from '../../types/abi';
 
 export interface PostConditionConfig {
     postConditions: PostCondition[];
     mode: PostConditionMode;
 }
 
-export interface WriteContractVariables {
+/** Typed mode: ABI present, args is a named object with autocomplete. */
+export interface TypedWriteContractVariables<
+    TAbi extends ClarityAbi,
+    TFn extends ExtractAbiFunctionNames<TAbi, 'public'>,
+> {
+    abi: TAbi;
+    address: string;
+    contract: string;
+    functionName: TFn;
+    args: PublicFunctionArgs<TAbi, TFn>;
+    pc: PostConditionConfig;
+}
+
+/** Untyped mode: no ABI, args is ClarityValue[] (original behavior). */
+export interface UntypedWriteContractVariables {
     address: string;
     contract: string;
     functionName: string;
@@ -17,8 +37,37 @@ export interface WriteContractVariables {
     pc: PostConditionConfig;
 }
 
+/** Backward-compatible alias for the untyped variant. */
+export type WriteContractVariables = UntypedWriteContractVariables;
+
 export interface WriteContractOptions {
     onSuccess?: (txHash: string) => void;
     onError?: (error: Error) => void;
     onSettled?: (txHash: string | undefined, error: Error | null) => void;
+}
+
+/** Overloaded async function: typed mode (with ABI) or untyped mode. */
+export interface WriteContractAsyncFn {
+    <
+        const TAbi extends ClarityAbi,
+        TFn extends ExtractAbiFunctionNames<TAbi, 'public'>,
+    >(
+        variables: TypedWriteContractVariables<TAbi, TFn>
+    ): Promise<string>;
+    (variables: UntypedWriteContractVariables): Promise<string>;
+}
+
+/** Overloaded fire-and-forget function: typed mode or untyped mode. */
+export interface WriteContractFn {
+    <
+        const TAbi extends ClarityAbi,
+        TFn extends ExtractAbiFunctionNames<TAbi, 'public'>,
+    >(
+        variables: TypedWriteContractVariables<TAbi, TFn>,
+        options?: WriteContractOptions
+    ): void;
+    (
+        variables: UntypedWriteContractVariables,
+        options?: WriteContractOptions
+    ): void;
 }

--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -16,6 +16,8 @@ export {
     type WriteContractVariables,
     type WriteContractOptions,
     type PostConditionConfig,
+    type TypedWriteContractVariables,
+    type UntypedWriteContractVariables,
 } from './hooks/use-write-contract/use-write-contract';
 export { useBnsName } from './hooks/use-bns-name';
 export { useWallets } from './hooks/use-wallets';
@@ -31,6 +33,12 @@ export type {
     MutationStatus,
 } from './provider/stacks-wallet-provider.types';
 
+export type {
+    TraitReference,
+    PublicFunctionName,
+    PublicFunctionArgs,
+} from './types/abi';
+
 // Constants
 export {
     SUPPORTED_STACKS_WALLETS,
@@ -44,3 +52,7 @@ export {
     getStacksWallets,
     type StacksWallets,
 } from './utils/get-stacks-wallets';
+export { createContractConfig } from './utils/create-contract-config';
+
+// Re-export ClarityAbi for convenience
+export type { ClarityAbi } from 'clarity-abitype';

--- a/packages/kit/src/types/abi.ts
+++ b/packages/kit/src/types/abi.ts
@@ -1,0 +1,26 @@
+import type {
+    ClarityAbi,
+    ClarityAbiArgToPrimitiveTypeValue,
+    ExtractAbiFunction,
+    ExtractAbiFunctionNames,
+    Pretty,
+} from 'clarity-abitype';
+
+/** Contract principal string in the format `address.contract-name` */
+export type TraitReference = `${string}.${string}`;
+
+/** Union of public function names from a Clarity ABI */
+export type PublicFunctionName<TAbi extends ClarityAbi> =
+    ExtractAbiFunctionNames<TAbi, 'public'>;
+
+/** Named args object for a specific public function, derived from ABI */
+export type PublicFunctionArgs<
+    TAbi extends ClarityAbi,
+    TFn extends ExtractAbiFunctionNames<TAbi, 'public'>,
+> = Pretty<{
+    [K in ExtractAbiFunction<
+        TAbi,
+        TFn,
+        'public'
+    >['args'][number] as K['name']]: ClarityAbiArgToPrimitiveTypeValue<K>;
+}>;

--- a/packages/kit/src/utils/create-contract-config.ts
+++ b/packages/kit/src/utils/create-contract-config.ts
@@ -1,0 +1,10 @@
+import type { ClarityAbi } from 'clarity-abitype';
+
+/** Pre-bind ABI + address + contract for reuse with useWriteContract. */
+export function createContractConfig<const TAbi extends ClarityAbi>(config: {
+    abi: TAbi;
+    address: string;
+    contract: string;
+}) {
+    return config;
+}

--- a/packages/kit/src/utils/to-clarity-value.ts
+++ b/packages/kit/src/utils/to-clarity-value.ts
@@ -1,0 +1,152 @@
+import type { ClarityValue } from '@stacks/transactions';
+import {
+    uintCV,
+    intCV,
+    boolCV,
+    noneCV,
+    someCV,
+    bufferCV,
+    stringAsciiCV,
+    stringUtf8CV,
+    listCV,
+    tupleCV,
+    standardPrincipalCV,
+    contractPrincipalCV,
+} from '@stacks/transactions';
+type AbiType = string | Record<string, unknown>;
+
+/** Loose ABI arg shape for runtime use — avoids importing ClarityAbiArg. */
+interface AbiArgLike {
+    name: string;
+    type: unknown;
+}
+
+/** Convert a JS primitive to a ClarityValue guided by an ABI type descriptor. */
+export function toClarityValue(value: unknown, abiType: AbiType): ClarityValue {
+    if (typeof abiType === 'string') {
+        switch (abiType) {
+            case 'uint128': {
+                if (typeof value !== 'bigint') {
+                    throw new Error(
+                        `@satoshai/kit: Expected bigint (uint128), got ${typeof value}`
+                    );
+                }
+                return uintCV(value);
+            }
+            case 'int128': {
+                if (typeof value !== 'bigint') {
+                    throw new Error(
+                        `@satoshai/kit: Expected bigint (int128), got ${typeof value}`
+                    );
+                }
+                return intCV(value);
+            }
+            case 'bool': {
+                if (typeof value !== 'boolean') {
+                    throw new Error(
+                        `@satoshai/kit: Expected boolean (bool), got ${typeof value}`
+                    );
+                }
+                return boolCV(value);
+            }
+            case 'principal':
+            case 'trait_reference': {
+                if (typeof value !== 'string') {
+                    throw new Error(
+                        `@satoshai/kit: Expected string (${abiType}), got ${typeof value}`
+                    );
+                }
+                if (value.includes('.')) {
+                    const [addr, ...rest] = value.split('.');
+                    return contractPrincipalCV(addr, rest.join('.'));
+                }
+                return standardPrincipalCV(value);
+            }
+            case 'none':
+                return noneCV();
+            default:
+                throw new Error(
+                    `@satoshai/kit: Unsupported ABI type "${abiType}"`
+                );
+        }
+    }
+
+    if ('buffer' in abiType) {
+        if (!(value instanceof Uint8Array)) {
+            throw new Error(
+                `@satoshai/kit: Expected Uint8Array (buffer), got ${typeof value}`
+            );
+        }
+        return bufferCV(value);
+    }
+    if ('string-ascii' in abiType) {
+        if (typeof value !== 'string') {
+            throw new Error(
+                `@satoshai/kit: Expected string (string-ascii), got ${typeof value}`
+            );
+        }
+        return stringAsciiCV(value);
+    }
+    if ('string-utf8' in abiType) {
+        if (typeof value !== 'string') {
+            throw new Error(
+                `@satoshai/kit: Expected string (string-utf8), got ${typeof value}`
+            );
+        }
+        return stringUtf8CV(value);
+    }
+    if ('optional' in abiType) {
+        if (value === null || value === undefined) return noneCV();
+        return someCV(toClarityValue(value, abiType.optional as AbiType));
+    }
+    if ('list' in abiType) {
+        if (!Array.isArray(value)) {
+            throw new Error(
+                `@satoshai/kit: Expected array (list), got ${typeof value}`
+            );
+        }
+        const listType = abiType.list as { type: AbiType };
+        return listCV(
+            value.map((item) => toClarityValue(item, listType.type))
+        );
+    }
+    if ('tuple' in abiType) {
+        if (typeof value !== 'object' || value === null) {
+            throw new Error(
+                `@satoshai/kit: Expected object (tuple), got ${value === null ? 'null' : typeof value}`
+            );
+        }
+        const entries = abiType.tuple as Array<{
+            name: string;
+            type: AbiType;
+        }>;
+        const obj = value as Record<string, unknown>;
+        const result: Record<string, ClarityValue> = {};
+        for (const entry of entries) {
+            result[entry.name] = toClarityValue(obj[entry.name], entry.type);
+        }
+        return tupleCV(result);
+    }
+
+    throw new Error(
+        `@satoshai/kit: Unsupported ABI type: ${JSON.stringify(abiType)}`
+    );
+}
+
+/** Convert a named args object to an ordered ClarityValue[] using ABI arg definitions. */
+export function namedArgsToClarityValues(
+    args: Record<string, unknown>,
+    abiArgs: readonly AbiArgLike[]
+): ClarityValue[] {
+    return abiArgs.map((abiArg) => {
+        if (!(abiArg.name in args)) {
+            throw new Error(
+                `@satoshai/kit: Missing argument "${abiArg.name}"`
+            );
+        }
+        return toClarityValue(
+            args[abiArg.name],
+            abiArg.type as AbiType
+        );
+    });
+}

--- a/packages/kit/tests/unit/hooks/use-write-contract.test.ts
+++ b/packages/kit/tests/unit/hooks/use-write-contract.test.ts
@@ -1,20 +1,18 @@
 // @vitest-environment happy-dom
 import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { uintCV, standardPrincipalCV, PostConditionMode } from '@stacks/transactions';
+import type { StxPostCondition } from '@stacks/transactions';
 
 const mockRequest = vi.fn();
 vi.mock('@stacks/connect', () => ({
     request: mockRequest,
 }));
 
-vi.mock('@stacks/transactions', () => ({
-    PostConditionMode: { Allow: 1, Deny: 2 },
-}));
-
 vi.mock('../../../src/hooks/use-address', () => ({
     useAddress: () => ({
         isConnected: true,
-        address: 'SP123',
+        address: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM',
         provider: 'leather',
     }),
 }));
@@ -35,12 +33,43 @@ const { useWriteContract } = await import(
     '../../../src/hooks/use-write-contract/use-write-contract'
 );
 
+const testAbi = {
+    functions: [
+        {
+            name: 'transfer',
+            access: 'public',
+            args: [
+                { name: 'amount', type: 'uint128' },
+                { name: 'sender', type: 'principal' },
+            ],
+            outputs: { type: { response: { ok: 'bool', error: 'uint128' } } },
+        },
+        {
+            name: 'get-balance',
+            access: 'read_only',
+            args: [{ name: 'who', type: 'principal' }],
+            outputs: { type: { response: { ok: 'uint128', error: 'none' } } },
+        },
+    ],
+    variables: [],
+    maps: [],
+    fungible_tokens: [],
+    non_fungible_tokens: [],
+} as const;
+
+const postCondition: StxPostCondition = {
+    type: 'stx-postcondition',
+    address: 'SP000000000000000000002Q6VF78',
+    condition: 'lte',
+    amount: 1000000n,
+};
+
 const baseVariables = {
-    address: 'SP1CONTRACT',
+    address: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM',
     contract: 'my-contract',
     functionName: 'transfer',
-    args: [],
-    pc: { postConditions: [], mode: 2 }, // Deny
+    args: [] as unknown[],
+    pc: { postConditions: [postCondition], mode: PostConditionMode.Deny },
 };
 
 beforeEach(() => {
@@ -87,7 +116,7 @@ describe('useWriteContract', () => {
         expect(mockRequest).toHaveBeenCalledWith(
             'stx_callContract',
             expect.objectContaining({
-                contract: 'SP1CONTRACT.my-contract',
+                contract: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.my-contract',
             })
         );
     });
@@ -100,7 +129,7 @@ describe('useWriteContract', () => {
         await act(async () => {
             await result.current.writeContractAsync({
                 ...baseVariables,
-                pc: { postConditions: [], mode: 1 }, // Allow
+                pc: { postConditions: [], mode: PostConditionMode.Allow },
             });
         });
 
@@ -263,5 +292,119 @@ describe('useWriteContract', () => {
         expect(result.current.isSuccess).toBe(true);
         expect(result.current.error).toBeNull();
         expect(result.current.data).toBe('0xabc123');
+    });
+});
+
+describe('useWriteContract – typed mode (with ABI)', () => {
+    it('converts named args to ClarityValues and calls request', async () => {
+        mockRequest.mockResolvedValue({ txid: '0xabc123' });
+
+        const { result } = renderHook(() => useWriteContract());
+
+        let txHash: string | undefined;
+        await act(async () => {
+            txHash = await result.current.writeContractAsync({
+                abi: testAbi,
+                address: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM',
+                contract: 'my-token',
+                functionName: 'transfer',
+                args: {
+                    amount: 1000000n,
+                    sender: 'SP000000000000000000002Q6VF78',
+                },
+                pc: baseVariables.pc,
+            });
+        });
+
+        expect(txHash).toBe('0xabc123');
+        expect(result.current.isSuccess).toBe(true);
+
+        expect(mockRequest).toHaveBeenCalledWith('stx_callContract', {
+            address: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM',
+            contract: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.my-token',
+            functionName: 'transfer',
+            functionArgs: [
+                uintCV(1000000n),
+                standardPrincipalCV('SP000000000000000000002Q6VF78'),
+            ],
+            postConditions: baseVariables.pc.postConditions,
+            postConditionMode: 'deny',
+            network: 'mainnet',
+        });
+    });
+
+    it('throws when function is not found in ABI', async () => {
+        const { result } = renderHook(() => useWriteContract());
+
+        await act(async () => {
+            await expect(
+                result.current.writeContractAsync({
+                    abi: testAbi,
+                    address: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM',
+                    contract: 'my-token',
+                    functionName: 'nonexistent' as never,
+                    args: {} as never,
+                    pc: baseVariables.pc,
+                })
+            ).rejects.toThrow(
+                '@satoshai/kit: Public function "nonexistent" not found in ABI'
+            );
+        });
+    });
+
+    it('throws when function is read_only (not public)', async () => {
+        const { result } = renderHook(() => useWriteContract());
+
+        await act(async () => {
+            await expect(
+                result.current.writeContractAsync({
+                    abi: testAbi,
+                    address: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM',
+                    contract: 'my-token',
+                    functionName: 'get-balance' as never,
+                    args: {} as never,
+                    pc: baseVariables.pc,
+                })
+            ).rejects.toThrow(
+                '@satoshai/kit: Public function "get-balance" not found in ABI'
+            );
+        });
+    });
+});
+
+describe('useWriteContract – untyped mode (backward compatible)', () => {
+    it('passes ClarityValue[] args directly to request', async () => {
+        mockRequest.mockResolvedValue({ txid: '0xdef456' });
+
+        const { result } = renderHook(() => useWriteContract());
+
+        const args = [
+            uintCV(1000000n),
+            standardPrincipalCV('SP000000000000000000002Q6VF78'),
+        ];
+
+        let txHash: string | undefined;
+        await act(async () => {
+            txHash = await result.current.writeContractAsync({
+                address: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM',
+                contract: 'my-token',
+                functionName: 'transfer',
+                args,
+                pc: baseVariables.pc,
+            });
+        });
+
+        expect(txHash).toBe('0xdef456');
+        expect(result.current.isSuccess).toBe(true);
+
+        expect(mockRequest).toHaveBeenCalledWith('stx_callContract', {
+            address: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM',
+            contract: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.my-token',
+            functionName: 'transfer',
+            functionArgs: args,
+            postConditions: baseVariables.pc.postConditions,
+            postConditionMode: 'deny',
+            network: 'mainnet',
+        });
     });
 });

--- a/packages/kit/tests/unit/utils/create-contract-config.test.ts
+++ b/packages/kit/tests/unit/utils/create-contract-config.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+
+import { createContractConfig } from '../../../src/utils/create-contract-config';
+
+const testAbi = {
+    functions: [
+        {
+            name: 'transfer',
+            access: 'public',
+            args: [
+                { name: 'amount', type: 'uint128' },
+                { name: 'sender', type: 'principal' },
+            ],
+            outputs: { type: { response: { ok: 'bool', error: 'uint128' } } },
+        },
+    ],
+    variables: [],
+    maps: [],
+    fungible_tokens: [],
+    non_fungible_tokens: [],
+} as const;
+
+describe('createContractConfig', () => {
+    it('returns the config object unchanged', () => {
+        const config = {
+            abi: testAbi,
+            address: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM',
+            contract: 'my-token',
+        };
+
+        const result = createContractConfig(config);
+
+        expect(result).toEqual(config);
+        expect(result.abi).toBe(config.abi);
+        expect(result.address).toBe(config.address);
+        expect(result.contract).toBe(config.contract);
+    });
+});

--- a/packages/kit/tests/unit/utils/to-clarity-value.test.ts
+++ b/packages/kit/tests/unit/utils/to-clarity-value.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest';
+import {
+    uintCV,
+    intCV,
+    trueCV,
+    falseCV,
+    noneCV,
+    someCV,
+    bufferCV,
+    stringAsciiCV,
+    stringUtf8CV,
+    listCV,
+    tupleCV,
+    standardPrincipalCV,
+    contractPrincipalCV,
+} from '@stacks/transactions';
+
+import {
+    toClarityValue,
+    namedArgsToClarityValues,
+} from '../../../src/utils/to-clarity-value';
+
+describe('toClarityValue', () => {
+    it('converts uint128', () => {
+        expect(toClarityValue(100n, 'uint128')).toEqual(uintCV(100n));
+    });
+
+    it('converts int128', () => {
+        expect(toClarityValue(-50n, 'int128')).toEqual(intCV(-50n));
+    });
+
+    it('converts bool true', () => {
+        expect(toClarityValue(true, 'bool')).toEqual(trueCV());
+    });
+
+    it('converts bool false', () => {
+        expect(toClarityValue(false, 'bool')).toEqual(falseCV());
+    });
+
+    it('converts standard principal', () => {
+        const addr = 'SP000000000000000000002Q6VF78';
+        expect(toClarityValue(addr, 'principal')).toEqual(
+            standardPrincipalCV(addr)
+        );
+    });
+
+    it('converts contract principal', () => {
+        const addr = 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.my-token';
+        expect(toClarityValue(addr, 'principal')).toEqual(
+            contractPrincipalCV(
+                'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM',
+                'my-token'
+            )
+        );
+    });
+
+    it('converts trait_reference as contract principal', () => {
+        const addr = 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.sip-010-trait';
+        expect(toClarityValue(addr, 'trait_reference')).toEqual(
+            contractPrincipalCV(
+                'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM',
+                'sip-010-trait'
+            )
+        );
+    });
+
+    it('converts none', () => {
+        expect(toClarityValue(null, 'none')).toEqual(noneCV());
+    });
+
+    it('converts buffer', () => {
+        const buf = new Uint8Array([1, 2, 3]);
+        expect(toClarityValue(buf, { buffer: { length: 3 } })).toEqual(
+            bufferCV(buf)
+        );
+    });
+
+    it('converts string-ascii', () => {
+        expect(
+            toClarityValue('hello', { 'string-ascii': { length: 32 } })
+        ).toEqual(stringAsciiCV('hello'));
+    });
+
+    it('converts string-utf8', () => {
+        expect(
+            toClarityValue('hello', { 'string-utf8': { length: 32 } })
+        ).toEqual(stringUtf8CV('hello'));
+    });
+
+    it('converts optional with value', () => {
+        expect(
+            toClarityValue(100n, { optional: 'uint128' })
+        ).toEqual(someCV(uintCV(100n)));
+    });
+
+    it('converts optional null to noneCV', () => {
+        expect(
+            toClarityValue(null, { optional: 'uint128' })
+        ).toEqual(noneCV());
+    });
+
+    it('converts list', () => {
+        expect(
+            toClarityValue([1n, 2n, 3n], {
+                list: { type: 'uint128', length: 3 },
+            })
+        ).toEqual(listCV([uintCV(1n), uintCV(2n), uintCV(3n)]));
+    });
+
+    it('converts tuple', () => {
+        expect(
+            toClarityValue(
+                { amount: 100n, sender: 'SP000000000000000000002Q6VF78' },
+                {
+                    tuple: [
+                        { name: 'amount', type: 'uint128' },
+                        { name: 'sender', type: 'principal' },
+                    ],
+                }
+            )
+        ).toEqual(
+            tupleCV({
+                amount: uintCV(100n),
+                sender: standardPrincipalCV(
+                    'SP000000000000000000002Q6VF78'
+                ),
+            })
+        );
+    });
+
+    // Error cases
+    it('throws on wrong type for uint128', () => {
+        expect(() => toClarityValue(100, 'uint128')).toThrow(
+            '@satoshai/kit: Expected bigint (uint128), got number'
+        );
+    });
+
+    it('throws on wrong type for int128', () => {
+        expect(() => toClarityValue('foo', 'int128')).toThrow(
+            '@satoshai/kit: Expected bigint (int128), got string'
+        );
+    });
+
+    it('throws on wrong type for bool', () => {
+        expect(() => toClarityValue(1, 'bool')).toThrow(
+            '@satoshai/kit: Expected boolean (bool), got number'
+        );
+    });
+
+    it('throws on wrong type for principal', () => {
+        expect(() => toClarityValue(123, 'principal')).toThrow(
+            '@satoshai/kit: Expected string (principal), got number'
+        );
+    });
+
+    it('throws on wrong type for buffer', () => {
+        expect(() =>
+            toClarityValue('not-bytes', { buffer: { length: 10 } })
+        ).toThrow(
+            '@satoshai/kit: Expected Uint8Array (buffer), got string'
+        );
+    });
+
+    it('throws on unsupported string type', () => {
+        expect(() => toClarityValue(null, 'unknown_type')).toThrow(
+            '@satoshai/kit: Unsupported ABI type "unknown_type"'
+        );
+    });
+});
+
+describe('namedArgsToClarityValues', () => {
+    const abiArgs = [
+        { name: 'amount', type: 'uint128' as const },
+        { name: 'sender', type: 'principal' as const },
+    ];
+
+    it('converts named args in ABI order', () => {
+        const result = namedArgsToClarityValues(
+            {
+                sender: 'SP000000000000000000002Q6VF78',
+                amount: 100n,
+            },
+            abiArgs
+        );
+
+        expect(result).toEqual([
+            uintCV(100n),
+            standardPrincipalCV('SP000000000000000000002Q6VF78'),
+        ]);
+    });
+
+    it('returns empty array for no args', () => {
+        expect(namedArgsToClarityValues({}, [])).toEqual([]);
+    });
+
+    it('throws on missing argument', () => {
+        expect(() =>
+            namedArgsToClarityValues({ amount: 100n }, abiArgs)
+        ).toThrow('@satoshai/kit: Missing argument "sender"');
+    });
+});

--- a/packages/kit/tsup.config.ts
+++ b/packages/kit/tsup.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   splitting: false,
   treeshake: true,
   outDir: 'dist',
-  external: ['react', 'react-dom', '@stacks/transactions', '@stacks/connect'],
+  external: ['react', 'react-dom', '@stacks/transactions', '@stacks/connect', 'clarity-abitype'],
   banner: {
     js: '"use client";',
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       bns-v2-sdk:
         specifier: ^2.1.0
         version: 2.1.1
+      clarity-abitype:
+        specifier: ^0.4.0
+        version: 0.4.0(@stacks/network@7.3.1)(@stacks/transactions@7.3.1)(typescript@5.9.3)
     devDependencies:
       '@stacks/transactions':
         specifier: ^7.2.0
@@ -1602,6 +1605,23 @@ packages:
     resolution: {integrity: sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==}
     engines: {node: '>= 0.10'}
 
+  clarity-abitype@0.4.0:
+    resolution: {integrity: sha512-kx991wMSt6lPs3lINz6Q5/oNdxhhR3cf1qYECay9EGquuzvbz4RzCtRCM8M65nrfdgafqjuFjlzbr6znkvlf5w==}
+    peerDependencies:
+      '@stacks/clarinet-sdk': '>= 3.0.0'
+      '@stacks/network': '>= 7.3.0'
+      '@stacks/transactions': '>= 7.3.0'
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      '@stacks/clarinet-sdk':
+        optional: true
+      '@stacks/network':
+        optional: true
+      '@stacks/transactions':
+        optional: true
+      typescript:
+        optional: true
+
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
@@ -2051,6 +2071,7 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@5.1.2:
@@ -5556,6 +5577,12 @@ snapshots:
       safe-buffer: 5.2.1
       to-buffer: 1.2.2
     optional: true
+
+  clarity-abitype@0.4.0(@stacks/network@7.3.1)(@stacks/transactions@7.3.1)(typescript@5.9.3):
+    optionalDependencies:
+      '@stacks/network': 7.3.1
+      '@stacks/transactions': 7.3.1
+      typescript: 5.9.3
 
   cliui@6.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Closes #35. Main feature for kit v1: type-safe contract interactions via `useWriteContract`.

- Pass a Clarity ABI (`as const`) to get **autocomplete on public function names** and **type-checked named args** — no manual `ClarityValue` construction
- Omitting `abi` preserves the current untyped API (backward compatible)
- `createContractConfig` helper for reusable contract bindings
- New type utilities: `PublicFunctionName`, `PublicFunctionArgs`, `TraitReference`
- Runtime converter (`toClarityValue`) handles all 12 Clarity types with clear error messages
- `clarity-abitype@0.4.0` as dependency for ABI type inference

## Test plan

- [x] 24 unit tests for `toClarityValue` / `namedArgsToClarityValues` (all type mappings + error cases)
- [x] 1 unit test for `createContractConfig`
- [x] 8 unit tests for `useWriteContract` (typed mode, untyped regression, state transitions, callbacks)
- [x] TypeScript typecheck passes
- [x] Build passes (ESM + CJS + .d.ts)
- [x] Lint passes
- [x] Example app builds and runs with typed demo
- [x] Manual test: connect wallet in example app, verify typed writeContract flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)