### PR TITLE
fix: use makeUnsignedContractCall for sponsored transactions

### DIFF
--- a/.changeset/fix-sponsored-contract-call.md
+++ b/.changeset/fix-sponsored-contract-call.md
@@ -1,0 +1,7 @@
+---
+"@satoshai/kit": minor
+---
+
+Fix `useSponsoredContractCall` to build sponsored transactions explicitly via `makeUnsignedContractCall` + `stx_signTransaction` instead of relying on wallet support for `sponsored: true` in `stx_callContract`.
+
+Expose `publicKey` from `useAddress()` — extracted from the wallet's `getAddresses` response during connection and persisted in localStorage.

--- a/examples/vite-react/src/app.tsx
+++ b/examples/vite-react/src/app.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { PostConditionMode, makeUnsignedSTXTokenTransfer, AnchorMode, tupleCV, stringAsciiCV, uintCV } from '@stacks/transactions';
+import { PostConditionMode, tupleCV, stringAsciiCV, uintCV } from '@stacks/transactions';
 import {
     StacksWalletProvider,
     useAddress,
@@ -9,7 +9,7 @@ import {
     useWallets,
     useWriteContract,
     useTransferSTX,
-    useSignTransaction,
+    useSponsoredContractCall,
     createContractConfig,
     useSignStructuredMessage,
 } from '@satoshai/kit';
@@ -76,7 +76,7 @@ export const App = () => {
 
 const Wallet = ({ useModal }: { useModal: boolean }) => {
     const { connect, reset, isPending } = useConnect();
-    const { address, isConnected, provider } = useAddress();
+    const { address, publicKey, isConnected, provider } = useAddress();
     const { disconnect } = useDisconnect();
     const { bnsName, isLoading: isBnsLoading } = useBnsName(address);
     const { wallets } = useWallets();
@@ -95,6 +95,10 @@ const Wallet = ({ useModal }: { useModal: boolean }) => {
                 <p>
                     <strong>Address:</strong> {address}
                 </p>
+                <p>
+                    <strong>Public Key:</strong>{' '}
+                    {publicKey ? <code>{publicKey}</code> : <em>not available</em>}
+                </p>
                 {isBnsLoading ? (
                     <p>Loading BNS name...</p>
                 ) : bnsName ? (
@@ -105,7 +109,7 @@ const Wallet = ({ useModal }: { useModal: boolean }) => {
                 <TransferSTXDemo />
                 <SignStructuredMessageDemo />
                 <WriteContractDemo address={address} />
-                <SignTransactionDemo address={address} />
+                <SponsoredContractCallDemo />
                 <button onClick={() => disconnect()}>Disconnect</button>
             </div>
         );
@@ -262,54 +266,47 @@ const SignStructuredMessageDemo = () => {
     );
 };
 
-// Demonstrates useSignTransaction hook
-const SignTransactionDemo = ({ address }: { address: string }) => {
-    const [broadcast, setBroadcast] = useState(false);
-    const { signTransaction, isPending, isSuccess, isError, data, error, reset } = useSignTransaction();
+// Demonstrates useSponsoredContractCall hook
+const SponsoredContractCallDemo = () => {
+    const { sponsoredContractCall, isPending, isSuccess, isError, data, error, reset } =
+        useSponsoredContractCall();
 
-    const handleSign = async () => {
-        const tx = await makeUnsignedSTXTokenTransfer({
-            recipient: 'SP000000000000000000002Q6VF78',
-            amount: 1000000n,
-            anchorMode: AnchorMode.Any,
-            fee: 200n,
-            nonce: 0n,
-            publicKey: '039e3c97ada3bc88a3e584e3f9472e0fab1300e8a78e1494d8bb1804bc3e6a2fa5',
-        });
-
-        signTransaction(
-            { transaction: tx.serialize(), broadcast },
+    const handleSponsoredCall = () => {
+        sponsoredContractCall(
             {
-                onSuccess: (result) => console.log('Transaction signed:', result),
-                onError: (err) => console.error('Transaction signing failed:', err),
+                ...myToken,
+                functionName: 'transfer',
+                args: {
+                    amount: 1000000n,
+                    sender: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM',
+                    recipient: 'SP000000000000000000002Q6VF78',
+                    memo: null,
+                },
+                pc: {
+                    postConditions: [],
+                    mode: PostConditionMode.Allow,
+                },
+            },
+            {
+                onSuccess: (signedTx) => console.log('Sponsored TX signed:', signedTx),
+                onError: (err) => console.error('Sponsored TX failed:', err),
             }
         );
     };
 
     return (
         <div style={{ marginTop: '1rem', marginBottom: '1rem' }}>
-            <h3>Sign Transaction</h3>
+            <h3>Sponsored Contract Call</h3>
             <p style={{ fontSize: '0.85rem', color: '#666' }}>
-                Signs an unsigned STX transfer of 1 STX to the burn address.
+                Signs a sponsored contract call (fee = 0). Returns signed TX hex — you would
+                send this to a sponsor service for co-signing and broadcast.
             </p>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', maxWidth: '400px' }}>
-                <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                    <input
-                        type="checkbox"
-                        checked={broadcast}
-                        onChange={(e) => setBroadcast(e.target.checked)}
-                        disabled={isPending}
-                    />
-                    Broadcast after signing
-                </label>
-                <button onClick={handleSign} disabled={isPending}>
-                    {isPending ? 'Signing...' : 'Sign Transaction'}
-                </button>
-            </div>
+            <button onClick={handleSponsoredCall} disabled={isPending}>
+                {isPending ? 'Signing...' : 'Sign Sponsored Call'}
+            </button>
             {isSuccess && data && (
                 <div style={{ color: 'green' }}>
-                    <p>Signed TX: {data.transaction.slice(0, 40)}...</p>
-                    {data.txid && <p>TXID: {data.txid}</p>}
+                    <p>Signed TX: {data.slice(0, 60)}...</p>
                     <button onClick={reset}>Clear</button>
                 </div>
             )}

--- a/packages/kit/src/hooks/use-address.ts
+++ b/packages/kit/src/hooks/use-address.ts
@@ -8,6 +8,7 @@ import { useStacksWalletContext } from '../provider/stacks-wallet-provider';
 type UseAddressReturn =
     | {
           address: undefined;
+          publicKey: undefined;
           isConnected: false;
           isConnecting: boolean;
           isDisconnected: boolean;
@@ -15,6 +16,7 @@ type UseAddressReturn =
       }
     | {
           address: string;
+          publicKey: string | undefined;
           isConnected: true;
           isConnecting: false;
           isDisconnected: false;
@@ -38,12 +40,13 @@ type UseAddressReturn =
  * ```
  */
 export const useAddress = (): UseAddressReturn => {
-    const { address, status, provider } = useStacksWalletContext();
+    const { address, publicKey, status, provider } = useStacksWalletContext();
 
     return useMemo(() => {
         if (status === 'connected' && address && provider) {
             return {
                 address,
+                publicKey,
                 isConnected: true as const,
                 isConnecting: false as const,
                 isDisconnected: false as const,
@@ -53,10 +56,11 @@ export const useAddress = (): UseAddressReturn => {
 
         return {
             address: undefined,
+            publicKey: undefined,
             isConnected: false as const,
             isConnecting: status === 'connecting',
             isDisconnected: status === 'disconnected',
             provider: undefined,
         };
-    }, [address, status, provider]);
+    }, [address, publicKey, status, provider]);
 };

--- a/packages/kit/src/hooks/use-sponsored-contract-call/use-sponsored-contract-call.ts
+++ b/packages/kit/src/hooks/use-sponsored-contract-call/use-sponsored-contract-call.ts
@@ -1,7 +1,10 @@
 'use client';
 
 import { request } from '@stacks/connect';
-import { PostConditionMode } from '@stacks/transactions';
+import {
+    makeUnsignedContractCall,
+    serializeTransaction,
+} from '@stacks/transactions';
 import { useCallback, useMemo, useState } from 'react';
 
 import {
@@ -65,7 +68,7 @@ import type {
  * @throws {WalletRequestError} If the wallet rejects or fails the request.
  */
 export const useSponsoredContractCall = () => {
-    const { isConnected, address, provider } = useAddress();
+    const { isConnected, address, publicKey, provider } = useAddress();
 
     const [data, setData] = useState<string | undefined>(undefined);
     const [error, setError] = useState<BaseError | null>(null);
@@ -84,6 +87,12 @@ export const useSponsoredContractCall = () => {
                 });
             }
 
+            if (!publicKey) {
+                throw new BaseError(
+                    'Public key not available — cannot build sponsored transaction'
+                );
+            }
+
             setStatus('pending');
             setError(null);
             setData(undefined);
@@ -91,22 +100,25 @@ export const useSponsoredContractCall = () => {
             const resolvedArgs = resolveArgs(variables);
 
             try {
-                const response = await request('stx_callContract', {
-                    address,
-                    contract: `${variables.address}.${variables.contract}`,
+                const unsignedTx = await makeUnsignedContractCall({
+                    contractAddress: variables.address,
+                    contractName: variables.contract,
                     functionName: variables.functionName,
                     functionArgs: resolvedArgs,
-                    postConditions: variables.pc.postConditions,
-                    postConditionMode:
-                        variables.pc.mode === PostConditionMode.Allow
-                            ? 'allow'
-                            : 'deny',
-                    network: getNetworkFromAddress(address),
+                    publicKey,
                     sponsored: true,
-                    fee: '0',
+                    fee: 0,
+                    postConditions: variables.pc.postConditions,
+                    postConditionMode: variables.pc.mode,
+                    network: getNetworkFromAddress(address),
                 });
 
-                const signedTx = response.transaction;
+                const result = await request('stx_signTransaction', {
+                    transaction: serializeTransaction(unsignedTx),
+                    broadcast: false,
+                });
+
+                const signedTx = result.transaction;
                 if (!signedTx) {
                     throw new Error('No signed transaction returned');
                 }
@@ -118,7 +130,7 @@ export const useSponsoredContractCall = () => {
                 const error = err instanceof BaseError
                     ? err
                     : new WalletRequestError({
-                          method: 'stx_callContract',
+                          method: 'stx_signTransaction',
                           wallet: provider ?? 'unknown',
                           cause: err instanceof Error ? err : new Error(String(err)),
                       });
@@ -127,7 +139,7 @@ export const useSponsoredContractCall = () => {
                 throw error;
             }
         },
-        [isConnected, address, provider]
+        [isConnected, address, publicKey, provider]
     ) as unknown as SponsoredContractCallAsyncFn;
 
     const sponsoredContractCall = useCallback(

--- a/packages/kit/src/provider/stacks-wallet-provider.helpers.ts
+++ b/packages/kit/src/provider/stacks-wallet-provider.helpers.ts
@@ -56,6 +56,7 @@ export const getOKXStacksAddress = async () => {
 
     return {
         address: stacksResponse.address,
+        publicKey: stacksResponse.publicKey,
         provider: 'okx' as const,
     };
 };
@@ -111,29 +112,26 @@ export const unregisterOkxProvider = () => {
 
 export const extractStacksAddress = (
     typedProvider: SupportedStacksWallet,
-    addresses: { address?: string; symbol?: string }[]
-) => {
+    addresses: { address?: string; symbol?: string; publicKey?: string }[]
+): { address: string; publicKey?: string } => {
     if (!addresses.length) {
         throw new Error(`No addresses provided for ${typedProvider} wallet`);
     }
 
     if (typedProvider === 'leather' || typedProvider === 'asigna') {
-        const stxAddress = addresses.find(
-            (addr) => addr.symbol === 'STX'
-        )?.address;
+        const entry = addresses.find((addr) => addr.symbol === 'STX');
 
-        if (stxAddress) return stxAddress;
+        if (entry?.address) return { address: entry.address, publicKey: entry.publicKey };
     }
 
-    const stacksAddress = addresses.find((addr) =>
-        addr.address?.startsWith('S')
-    )?.address;
+    const entry = addresses.find((addr) => addr.address?.startsWith('S'));
 
-    if (stacksAddress) return stacksAddress;
+    if (entry?.address) return { address: entry.address, publicKey: entry.publicKey };
 
-    const legacyAddress = addresses[2]?.address;
+    const legacyEntry = addresses[2];
 
-    if (legacyAddress?.startsWith('S')) return legacyAddress;
+    if (legacyEntry?.address?.startsWith('S'))
+        return { address: legacyEntry.address, publicKey: legacyEntry.publicKey };
 
     throw new Error(
         `No valid Stacks address found for ${typedProvider} wallet`

--- a/packages/kit/src/provider/stacks-wallet-provider.tsx
+++ b/packages/kit/src/provider/stacks-wallet-provider.tsx
@@ -97,6 +97,7 @@ export const StacksWalletProvider = ({
     onDisconnect,
 }: StacksWalletProviderProps) => {
     const [address, setAddress] = useState<string | undefined>();
+    const [publicKey, setPublicKey] = useState<string | undefined>();
     const [provider, setProvider] = useState<
         SupportedStacksWallet | undefined
     >();
@@ -154,6 +155,7 @@ export const StacksWalletProvider = ({
                 if (persisted.provider === 'okx') {
                     const data = await getOKXStacksAddress();
                     setAddress(data.address);
+                    setPublicKey(data.publicKey);
                     setProvider(data.provider);
                     return;
                 }
@@ -175,6 +177,7 @@ export const StacksWalletProvider = ({
                 }
 
                 setAddress(persisted.address);
+                setPublicKey(persisted.publicKey);
                 setProvider(persisted.provider);
                 setSelectedProviderId(
                     STACKS_TO_STACKS_CONNECT_PROVIDERS[persisted.provider]
@@ -246,14 +249,15 @@ export const StacksWalletProvider = ({
                         );
                     }
 
-                    const extractedAddress = extractStacksAddress(
+                    const extracted = extractStacksAddress(
                         resolvedProvider,
                         data.addresses
                     );
 
-                    setAddress(extractedAddress);
+                    setAddress(extracted.address);
+                    setPublicKey(extracted.publicKey);
                     setProvider(resolvedProvider);
-                    options?.onSuccess?.(extractedAddress, resolvedProvider);
+                    options?.onSuccess?.(extracted.address, resolvedProvider);
                 } catch (error) {
                     if (connectGenRef.current !== gen) return;
                     console.error('Failed to connect wallet:', error);
@@ -314,6 +318,7 @@ export const StacksWalletProvider = ({
                     const data = await getOKXStacksAddress();
                     if (connectGenRef.current !== gen) return;
                     setAddress(data.address);
+                    setPublicKey(data.publicKey);
                     setProvider(data.provider);
                     options?.onSuccess?.(data.address, data.provider);
                     return;
@@ -354,14 +359,15 @@ export const StacksWalletProvider = ({
 
                 if (connectGenRef.current !== gen) return;
 
-                const extractedAddress = extractStacksAddress(
+                const extracted = extractStacksAddress(
                     typedProvider,
                     data.addresses
                 );
 
-                setAddress(extractedAddress);
+                setAddress(extracted.address);
+                setPublicKey(extracted.publicKey);
                 setProvider(typedProvider);
-                options?.onSuccess?.(extractedAddress, typedProvider);
+                options?.onSuccess?.(extracted.address, typedProvider);
             } catch (error) {
                 if (connectGenRef.current !== gen) return;
                 console.error('Failed to connect wallet:', error);
@@ -392,6 +398,7 @@ export const StacksWalletProvider = ({
         (callback?: () => void) => {
             localStorage.removeItem(LOCAL_STORAGE_STACKS);
             setAddress(undefined);
+            setPublicKey(undefined);
             setProvider(undefined);
             getSelectedProvider()?.disconnect?.();
             clearSelectedProviderId();
@@ -406,9 +413,9 @@ export const StacksWalletProvider = ({
 
         localStorage.setItem(
             LOCAL_STORAGE_STACKS,
-            JSON.stringify({ address, provider })
+            JSON.stringify({ address, publicKey, provider })
         );
-    }, [address, provider]);
+    }, [address, publicKey, provider]);
 
     useEffect(() => {
         const isConnected = !!address && !!provider;
@@ -438,6 +445,7 @@ export const StacksWalletProvider = ({
     const handleWcDisconnect = useCallback(() => {
         localStorage.removeItem(LOCAL_STORAGE_STACKS);
         setAddress(undefined);
+        setPublicKey(undefined);
         setProvider(undefined);
         onDisconnect?.();
     }, [onDisconnect]);
@@ -472,12 +480,13 @@ export const StacksWalletProvider = ({
 
     const value = useMemo((): WalletContextValue => {
         const walletState: WalletState = isConnecting
-            ? { status: 'connecting', address: undefined, provider: undefined }
+            ? { status: 'connecting', address: undefined, publicKey: undefined, provider: undefined }
             : address && provider
-            ? { status: 'connected', address, provider }
+            ? { status: 'connected', address, publicKey, provider }
             : {
                   status: 'disconnected',
                   address: undefined,
+                  publicKey: undefined,
                   provider: undefined,
               };
 
@@ -488,7 +497,7 @@ export const StacksWalletProvider = ({
             reset,
             wallets: walletInfos,
         };
-    }, [address, provider, isConnecting, connect, disconnect, reset, walletInfosKey]);
+    }, [address, publicKey, provider, isConnecting, connect, disconnect, reset, walletInfosKey]);
 
     return (
         <StacksWalletContext.Provider value={value}>

--- a/packages/kit/src/provider/stacks-wallet-provider.types.ts
+++ b/packages/kit/src/provider/stacks-wallet-provider.types.ts
@@ -66,16 +66,19 @@ export type WalletState =
     | {
           status: 'disconnected';
           address: undefined;
+          publicKey: undefined;
           provider: undefined;
       }
     | {
           status: 'connecting';
           address: undefined;
+          publicKey: undefined;
           provider: undefined;
       }
     | {
           status: 'connected';
           address: string;
+          publicKey: string | undefined;
           provider: SupportedStacksWallet;
       };
 

--- a/packages/kit/src/types/global.d.ts
+++ b/packages/kit/src/types/global.d.ts
@@ -18,7 +18,7 @@ declare global {
                     recipient?: string;
                     amount?: string;
                     memo?: string;
-                }) => Promise<{ txHash: string }>;
+                }) => Promise<{ txHash: string; signature: string }>;
                 signMessage: (data: {
                     message: string;
                 }) => Promise<{ publicKey: string; signature: string }>;

--- a/packages/kit/src/types/global.d.ts
+++ b/packages/kit/src/types/global.d.ts
@@ -2,7 +2,7 @@ declare global {
     interface Window {
         okxwallet?: {
             stacks: {
-                connect: () => Promise<{ address: string }>;
+                connect: () => Promise<{ address: string; publicKey?: string }>;
                 signTransaction: (params: {
                     stxAddress: string;
                     txType: string;

--- a/packages/kit/src/utils/get-local-storage-wallet.ts
+++ b/packages/kit/src/utils/get-local-storage-wallet.ts
@@ -10,6 +10,7 @@ import { SUPPORTED_STACKS_WALLETS } from '../constants/wallets';
  */
 export const getLocalStorageWallet = (): {
     address: string;
+    publicKey?: string;
     provider: SupportedStacksWallet;
 } | null => {
     if (typeof window === 'undefined') return null;
@@ -21,6 +22,7 @@ export const getLocalStorageWallet = (): {
     try {
         const data = JSON.parse(stored) as {
             address: string;
+            publicKey?: string;
             provider: SupportedStacksWallet;
         };
 

--- a/packages/kit/tests/unit/hooks/use-sponsored-contract-call.test.ts
+++ b/packages/kit/tests/unit/hooks/use-sponsored-contract-call.test.ts
@@ -9,10 +9,24 @@ vi.mock('@stacks/connect', () => ({
     request: mockRequest,
 }));
 
+const mockMakeUnsignedContractCall = vi.fn();
+const mockSerializeTransaction = vi.fn();
+vi.mock('@stacks/transactions', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@stacks/transactions')>();
+    return {
+        ...actual,
+        makeUnsignedContractCall: (...args: unknown[]) =>
+            mockMakeUnsignedContractCall(...args),
+        serializeTransaction: (...args: unknown[]) =>
+            mockSerializeTransaction(...args),
+    };
+});
+
 vi.mock('../../../src/hooks/use-address', () => ({
     useAddress: () => ({
         isConnected: true,
         address: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM',
+        publicKey: '03abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab',
         provider: 'leather',
     }),
 }));
@@ -58,8 +72,16 @@ const baseVariables = {
     pc: { postConditions: [postCondition], mode: PostConditionMode.Deny },
 };
 
+const FAKE_UNSIGNED_TX = { fake: 'unsigned-tx' };
+const FAKE_SERIALIZED = '0x00serialized';
+
 beforeEach(() => {
     mockRequest.mockReset();
+    mockMakeUnsignedContractCall.mockReset();
+    mockSerializeTransaction.mockReset();
+
+    mockMakeUnsignedContractCall.mockResolvedValue(FAKE_UNSIGNED_TX);
+    mockSerializeTransaction.mockReturnValue(FAKE_SERIALIZED);
 });
 
 describe('useSponsoredContractCall', () => {
@@ -90,7 +112,7 @@ describe('useSponsoredContractCall', () => {
         expect(result.current.error).toBeNull();
     });
 
-    it('formats contract as address.contract', async () => {
+    it('builds unsigned tx with makeUnsignedContractCall and signs via stx_signTransaction', async () => {
         mockRequest.mockResolvedValue({ transaction: '0x0200signed' });
 
         const { result } = renderHook(() => useSponsoredContractCall());
@@ -99,82 +121,39 @@ describe('useSponsoredContractCall', () => {
             await result.current.sponsoredContractCallAsync(baseVariables);
         });
 
-        expect(mockRequest).toHaveBeenCalledWith(
-            'stx_callContract',
+        expect(mockMakeUnsignedContractCall).toHaveBeenCalledWith(
             expect.objectContaining({
-                contract: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.my-contract',
-            })
-        );
-    });
-
-    it('passes sponsored: true and fee: "0" in request', async () => {
-        mockRequest.mockResolvedValue({ transaction: '0x0200signed' });
-
-        const { result } = renderHook(() => useSponsoredContractCall());
-
-        await act(async () => {
-            await result.current.sponsoredContractCallAsync(baseVariables);
-        });
-
-        expect(mockRequest).toHaveBeenCalledWith(
-            'stx_callContract',
-            expect.objectContaining({
+                contractAddress: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM',
+                contractName: 'my-contract',
+                functionName: 'deposit',
+                publicKey: '03abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab',
                 sponsored: true,
-                fee: '0',
-            })
-        );
-    });
-
-    it('maps PostConditionMode.Allow to allow string', async () => {
-        mockRequest.mockResolvedValue({ transaction: '0x0200signed' });
-
-        const { result } = renderHook(() => useSponsoredContractCall());
-
-        await act(async () => {
-            await result.current.sponsoredContractCallAsync({
-                ...baseVariables,
-                pc: { postConditions: [], mode: PostConditionMode.Allow },
-            });
-        });
-
-        expect(mockRequest).toHaveBeenCalledWith(
-            'stx_callContract',
-            expect.objectContaining({
-                postConditionMode: 'allow',
-            })
-        );
-    });
-
-    it('maps PostConditionMode.Deny to deny string', async () => {
-        mockRequest.mockResolvedValue({ transaction: '0x0200signed' });
-
-        const { result } = renderHook(() => useSponsoredContractCall());
-
-        await act(async () => {
-            await result.current.sponsoredContractCallAsync(baseVariables);
-        });
-
-        expect(mockRequest).toHaveBeenCalledWith(
-            'stx_callContract',
-            expect.objectContaining({
-                postConditionMode: 'deny',
-            })
-        );
-    });
-
-    it('passes network from getNetworkFromAddress', async () => {
-        mockRequest.mockResolvedValue({ transaction: '0x0200signed' });
-
-        const { result } = renderHook(() => useSponsoredContractCall());
-
-        await act(async () => {
-            await result.current.sponsoredContractCallAsync(baseVariables);
-        });
-
-        expect(mockRequest).toHaveBeenCalledWith(
-            'stx_callContract',
-            expect.objectContaining({
+                fee: 0,
                 network: 'mainnet',
+            })
+        );
+
+        expect(mockSerializeTransaction).toHaveBeenCalledWith(FAKE_UNSIGNED_TX);
+
+        expect(mockRequest).toHaveBeenCalledWith('stx_signTransaction', {
+            transaction: FAKE_SERIALIZED,
+            broadcast: false,
+        });
+    });
+
+    it('passes post conditions to makeUnsignedContractCall', async () => {
+        mockRequest.mockResolvedValue({ transaction: '0x0200signed' });
+
+        const { result } = renderHook(() => useSponsoredContractCall());
+
+        await act(async () => {
+            await result.current.sponsoredContractCallAsync(baseVariables);
+        });
+
+        expect(mockMakeUnsignedContractCall).toHaveBeenCalledWith(
+            expect.objectContaining({
+                postConditions: [postCondition],
+                postConditionMode: PostConditionMode.Deny,
             })
         );
     });
@@ -298,7 +277,7 @@ describe('useSponsoredContractCall', () => {
 });
 
 describe('useSponsoredContractCall – typed mode (with ABI)', () => {
-    it('converts named args to ClarityValues and calls request with sponsored params', async () => {
+    it('converts named args to ClarityValues and builds sponsored tx', async () => {
         mockRequest.mockResolvedValue({ transaction: '0x0200signed' });
 
         const { result } = renderHook(() => useSponsoredContractCall());
@@ -321,20 +300,19 @@ describe('useSponsoredContractCall – typed mode (with ABI)', () => {
         expect(signedTx).toBe('0x0200signed');
         expect(result.current.isSuccess).toBe(true);
 
-        expect(mockRequest).toHaveBeenCalledWith('stx_callContract', {
-            address: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM',
-            contract: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.my-vault',
-            functionName: 'deposit',
-            functionArgs: [
-                uintCV(1000000n),
-                standardPrincipalCV('SP000000000000000000002Q6VF78'),
-            ],
-            postConditions: baseVariables.pc.postConditions,
-            postConditionMode: 'deny',
-            network: 'mainnet',
-            sponsored: true,
-            fee: '0',
-        });
+        expect(mockMakeUnsignedContractCall).toHaveBeenCalledWith(
+            expect.objectContaining({
+                contractAddress: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM',
+                contractName: 'my-vault',
+                functionName: 'deposit',
+                functionArgs: [
+                    uintCV(1000000n),
+                    standardPrincipalCV('SP000000000000000000002Q6VF78'),
+                ],
+                sponsored: true,
+                fee: 0,
+            })
+        );
     });
 
     it('throws when function is not found in ABI', async () => {
@@ -358,7 +336,7 @@ describe('useSponsoredContractCall – typed mode (with ABI)', () => {
 });
 
 describe('useSponsoredContractCall – untyped mode', () => {
-    it('passes ClarityValue[] args directly to request', async () => {
+    it('passes ClarityValue[] args directly to makeUnsignedContractCall', async () => {
         mockRequest.mockResolvedValue({ transaction: '0x0200signed' });
 
         const { result } = renderHook(() => useSponsoredContractCall());
@@ -382,16 +360,18 @@ describe('useSponsoredContractCall – untyped mode', () => {
         expect(signedTx).toBe('0x0200signed');
         expect(result.current.isSuccess).toBe(true);
 
-        expect(mockRequest).toHaveBeenCalledWith('stx_callContract', {
-            address: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM',
-            contract: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.my-vault',
-            functionName: 'deposit',
-            functionArgs: args,
-            postConditions: baseVariables.pc.postConditions,
-            postConditionMode: 'deny',
-            network: 'mainnet',
-            sponsored: true,
-            fee: '0',
+        expect(mockMakeUnsignedContractCall).toHaveBeenCalledWith(
+            expect.objectContaining({
+                contractAddress: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM',
+                contractName: 'my-vault',
+                functionName: 'deposit',
+                functionArgs: args,
+            })
+        );
+
+        expect(mockRequest).toHaveBeenCalledWith('stx_signTransaction', {
+            transaction: FAKE_SERIALIZED,
+            broadcast: false,
         });
     });
 });


### PR DESCRIPTION
## Summary

- Fix `useSponsoredContractCall` to build sponsored transactions explicitly via `makeUnsignedContractCall` + `stx_signTransaction` instead of relying on wallet support for `sponsored: true` in `stx_callContract` (wallets don't honor this flag)
- Extract and store `publicKey` from the wallet's `getAddresses` response during connection, persist in localStorage
- Expose `publicKey` via `useAddress()` — backward-compatible addition to the discriminated union
- Align OKX global types with actual API (`connect()` returns `publicKey`, `signTransaction()` returns `signature`)
- Update example app: replace removed `SignTransactionDemo` with `SponsoredContractCallDemo`, display `publicKey`

### What changed
- **Provider helpers**: `extractStacksAddress` returns `{ address, publicKey }` instead of just a string
- **Provider component**: stores `publicKey` in state, persists to localStorage, clears on disconnect
- **`useAddress()`**: exposes `publicKey: string | undefined` when connected
- **`useSponsoredContractCall`**: builds unsigned tx with `makeUnsignedContractCall({ publicKey, sponsored: true, fee: 0 })`, signs via `request('stx_signTransaction', { transaction, broadcast: false })`
- **OKX types**: `connect()` → `{ address, publicKey? }`, `signTransaction()` → `{ txHash, signature }`
- **Example app**: sponsored call demo + publicKey display

## Test plan

- [x] All 218 tests pass (27 test files)
- [x] Build succeeds (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] Typecheck passes (`tsc --noEmit`)
- [x] Example app typechecks and runs (`pnpm dev`)
- [ ] Live test: connect Leather/Xverse, verify publicKey displayed, test sponsored call signing

🤖 Generated with [Claude Code](https://claude.com/claude-code)