### PR TITLE
fix: sync publicKey on Xverse in-wallet account switch

### DIFF
--- a/.changeset/xverse-publickey-account-change.md
+++ b/.changeset/xverse-publickey-account-change.md
@@ -1,0 +1,5 @@
+---
+'@satoshai/kit': patch
+---
+
+Fix stale `publicKey` after Xverse in-wallet account switch. The cached `publicKey` is now refreshed alongside `address` when Xverse emits `accountChange`, so `useSponsoredContractCall` builds unsigned transactions with the active account's public key and the resulting signed tx passes `verifyOrigin()`.

--- a/.changeset/xverse-publickey-account-change.md
+++ b/.changeset/xverse-publickey-account-change.md
@@ -3,3 +3,5 @@
 ---
 
 Fix stale `publicKey` after Xverse in-wallet account switch. The cached `publicKey` is now refreshed alongside `address` when Xverse emits `accountChange`, so `useSponsoredContractCall` builds unsigned transactions with the active account's public key and the resulting signed tx passes `verifyOrigin()`.
+
+Also bumps `bns-v2-sdk` (^2.1 → ^2.2) and `clarity-abitype` (^0.4 → ^0.6) along with several devDeps; no public API impact.

--- a/examples/nextjs/app/page.tsx
+++ b/examples/nextjs/app/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import {
     PostConditionMode,
-    makeUnsignedSTXTokenTransfer,
+    deserializeTransaction,
     tupleCV,
     stringAsciiCV,
     uintCV,
@@ -17,8 +17,8 @@ import {
     useWriteContract,
     useTransferSTX,
     useSignMessage,
-    useSignTransaction,
     useSignStructuredMessage,
+    useSponsoredContractCall,
     createContractConfig,
 } from '@satoshai/kit';
 
@@ -58,7 +58,7 @@ const myToken = createContractConfig({
 
 export default function Home() {
     const { connect, reset, isPending } = useConnect();
-    const { address, isConnected, provider } = useAddress();
+    const { address, publicKey, isConnected, provider } = useAddress();
     const { disconnect } = useDisconnect();
     const { bnsName, isLoading: isBnsLoading } = useBnsName(address);
     const { wallets } = useWallets();
@@ -82,6 +82,10 @@ export default function Home() {
                 <p>
                     <strong>Address:</strong> {address}
                 </p>
+                <p>
+                    <strong>Public Key:</strong>{' '}
+                    {publicKey ? <code>{publicKey}</code> : <em>not available</em>}
+                </p>
                 {isBnsLoading ? (
                     <p>Loading BNS name...</p>
                 ) : bnsName ? (
@@ -93,7 +97,7 @@ export default function Home() {
                 <TransferSTXDemo />
                 <SignStructuredMessageDemo />
                 <WriteContractDemo address={address} />
-                <SignTransactionDemo />
+                <SponsoredContractCallDemo address={address} />
                 <button onClick={() => disconnect()}>Disconnect</button>
             </div>
         );
@@ -293,69 +297,10 @@ function SignStructuredMessageDemo() {
     );
 }
 
-function SignTransactionDemo() {
-    const [broadcast, setBroadcast] = useState(false);
-    const { signTransaction, isPending, isSuccess, isError, data, error, reset } = useSignTransaction();
-
-    const handleSign = async () => {
-        const tx = await makeUnsignedSTXTokenTransfer({
-            recipient: 'SP000000000000000000002Q6VF78',
-            amount: 1000000n,
-            fee: 200n,
-            nonce: 0n,
-            publicKey: '039e3c97ada3bc88a3e584e3f9472e0fab1300e8a78e1494d8bb1804bc3e6a2fa5',
-        });
-
-        signTransaction(
-            { transaction: tx.serialize(), broadcast },
-            {
-                onSuccess: (result) => console.log('Transaction signed:', result),
-                onError: (err) => console.error('Transaction signing failed:', err),
-            }
-        );
-    };
-
-    return (
-        <div style={{ marginTop: '1rem', marginBottom: '1rem' }}>
-            <h3>Sign Transaction</h3>
-            <p style={{ fontSize: '0.85rem', color: '#666' }}>
-                Signs an unsigned STX transfer of 1 STX to the burn address.
-            </p>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', maxWidth: '400px' }}>
-                <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                    <input
-                        type="checkbox"
-                        checked={broadcast}
-                        onChange={(e) => setBroadcast(e.target.checked)}
-                        disabled={isPending}
-                    />
-                    Broadcast after signing
-                </label>
-                <button onClick={handleSign} disabled={isPending}>
-                    {isPending ? 'Signing...' : 'Sign Transaction'}
-                </button>
-            </div>
-            {isSuccess && data && (
-                <div style={{ color: 'green' }}>
-                    <p>Signed TX: {data.transaction.slice(0, 40)}...</p>
-                    {data.txid && <p>TXID: {data.txid}</p>}
-                    <button onClick={reset}>Clear</button>
-                </div>
-            )}
-            {isError && (
-                <p style={{ color: 'red' }}>
-                    Error: {error?.message} <button onClick={reset}>Clear</button>
-                </p>
-            )}
-        </div>
-    );
-}
-
 function WriteContractDemo({ address }: { address: string }) {
     const { writeContract, isPending, isSuccess, isError, data, error } = useWriteContract();
 
     const handleTransfer = () => {
-        // Typed mode: functionName autocompletes, args are type-checked
         writeContract(
             {
                 ...myToken,
@@ -386,6 +331,91 @@ function WriteContractDemo({ address }: { address: string }) {
             </button>
             {isSuccess && <p style={{ color: 'green' }}>TX: {data}</p>}
             {isError && <p style={{ color: 'red' }}>Error: {error?.message}</p>}
+        </div>
+    );
+}
+
+function SponsoredContractCallDemo({ address }: { address: string }) {
+    const { sponsoredContractCall, isPending, isSuccess, isError, data, error, reset } =
+        useSponsoredContractCall();
+    const [verifyResult, setVerifyResult] = useState<
+        { ok: true; hash: string } | { ok: false; message: string } | null
+    >(null);
+
+    const handleSponsoredCall = () => {
+        setVerifyResult(null);
+        sponsoredContractCall(
+            {
+                ...myToken,
+                functionName: 'transfer',
+                args: {
+                    amount: 1000000n,
+                    sender: address,
+                    recipient: 'SP000000000000000000002Q6VF78',
+                    memo: null,
+                },
+                pc: {
+                    postConditions: [],
+                    mode: PostConditionMode.Allow,
+                },
+            },
+            {
+                onSuccess: (signedTx) => {
+                    console.log('Sponsored TX signed:', signedTx);
+                    // Run the same verifyOrigin() the sponsor service would run.
+                    // Throws if condition.signer (hash160 of declared publicKey)
+                    // doesn't match the recovered signature pubkey hash.
+                    try {
+                        const tx = deserializeTransaction(signedTx);
+                        const hash = tx.verifyOrigin();
+                        setVerifyResult({ ok: true, hash });
+                    } catch (err) {
+                        setVerifyResult({
+                            ok: false,
+                            message: err instanceof Error ? err.message : String(err),
+                        });
+                    }
+                },
+                onError: (err) => console.error('Sponsored TX failed:', err),
+            }
+        );
+    };
+
+    return (
+        <div style={{ marginTop: '1rem', marginBottom: '1rem' }}>
+            <h3>Sponsored Contract Call</h3>
+            <p style={{ fontSize: '0.85rem', color: '#666' }}>
+                Signs a sponsored contract call (fee = 0) and runs{' '}
+                <code>verifyOrigin()</code> client-side. To repro the stale-publicKey bug:
+                connect Xverse with account A, switch to account B inside Xverse, then click
+                the button. Without the fix, <code>verifyOrigin()</code> throws because the tx
+                declares signer = hash160(A) but the signature recovers pubkey B.
+            </p>
+            <button onClick={handleSponsoredCall} disabled={isPending}>
+                {isPending ? 'Signing...' : 'Sign Sponsored Call'}
+            </button>
+            {isSuccess && data && (
+                <div style={{ color: 'green' }}>
+                    <p>Signed TX: {data.slice(0, 60)}...</p>
+                </div>
+            )}
+            {verifyResult?.ok && (
+                <p style={{ color: 'green' }}>
+                    verifyOrigin() passed — origin sig hash: {verifyResult.hash.slice(0, 16)}...{' '}
+                    <button onClick={() => { setVerifyResult(null); reset(); }}>Clear</button>
+                </p>
+            )}
+            {verifyResult && !verifyResult.ok && (
+                <p style={{ color: 'red' }}>
+                    verifyOrigin() FAILED: {verifyResult.message}{' '}
+                    <button onClick={() => { setVerifyResult(null); reset(); }}>Clear</button>
+                </p>
+            )}
+            {isError && (
+                <p style={{ color: 'red' }}>
+                    Error: {error?.message} <button onClick={reset}>Clear</button>
+                </p>
+            )}
         </div>
     );
 }

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -8,14 +8,14 @@
   },
   "dependencies": {
     "@satoshai/kit": "workspace:*",
-    "@stacks/transactions": "^7.2.0",
-    "next": "^16.0.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "@stacks/transactions": "^7.4.0",
+    "next": "^16.2.6",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6"
   },
   "devDependencies": {
-    "@types/react": "^19.2.2",
-    "@types/react-dom": "^19.2.2",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "typescript": "^5.7.0"
   }
 }

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -34,8 +34,8 @@
   },
   "dependencies": {
     "@stacks/connect": "8.2.6",
-    "bns-v2-sdk": "^2.1.0",
-    "clarity-abitype": "^0.4.0"
+    "bns-v2-sdk": "^2.2.0",
+    "clarity-abitype": "^0.6.0"
   },
   "peerDependencies": {
     "@stacks/transactions": ">=7.0.0",
@@ -43,16 +43,16 @@
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
-    "@stacks/transactions": "^7.2.0",
+    "@stacks/transactions": "^7.4.0",
     "@testing-library/react": "^16.3.2",
-    "@types/node": "^22.0.0",
-    "@types/react": "^19.2.2",
-    "@types/react-dom": "^19.2.2",
+    "@types/node": "^25.6.2",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "@vitest/coverage-v8": "^3.2.4",
-    "happy-dom": "^20.7.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "tsup": "^8.3.0",
+    "happy-dom": "^20.9.0",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6",
+    "tsup": "^8.5.1",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   },

--- a/packages/kit/src/hooks/use-xverse/use-xverse.helpers.ts
+++ b/packages/kit/src/hooks/use-xverse/use-xverse.helpers.ts
@@ -31,16 +31,18 @@ export const extractAndValidateStacksAddress = (
     addresses:
         | {
               address: string;
+              publicKey?: string;
               addressType: string;
               purpose: string;
           }[]
         | undefined,
     currentAddress: string | undefined,
-    onAddressChange: (address: string) => void,
+    currentPublicKey: string | undefined,
+    onAccountChange: (address: string, publicKey: string) => void,
     connect: () => Promise<void>
 ) => {
     if (!addresses || !Array.isArray(addresses)) {
-        void connect();
+        connect();
         return;
     }
 
@@ -48,12 +50,15 @@ export const extractAndValidateStacksAddress = (
         (acc) => acc.purpose === 'stacks' || acc.addressType === 'stacks'
     );
 
-    if (!stacksAccount?.address) {
-        void connect();
+    if (!stacksAccount?.address || !stacksAccount.publicKey) {
+        connect();
         return;
     }
 
-    if (stacksAccount.address !== currentAddress) {
-        onAddressChange(stacksAccount.address);
+    if (
+        stacksAccount.address !== currentAddress ||
+        stacksAccount.publicKey !== currentPublicKey
+    ) {
+        onAccountChange(stacksAccount.address, stacksAccount.publicKey);
     }
 };

--- a/packages/kit/src/hooks/use-xverse/use-xverse.ts
+++ b/packages/kit/src/hooks/use-xverse/use-xverse.ts
@@ -54,7 +54,7 @@ export const useXverse = ({
             }
         };
 
-        void checkProvider();
+        checkProvider();
     }, [provider]);
 
     // Re-run on connect/disconnect (hasAddress flip), not on account switches.
@@ -106,7 +106,7 @@ export const useXverse = ({
             }
         };
 
-        void setupXverse();
+        setupXverse();
 
         return () => {
             cancelled = true;

--- a/packages/kit/src/hooks/use-xverse/use-xverse.ts
+++ b/packages/kit/src/hooks/use-xverse/use-xverse.ts
@@ -1,5 +1,5 @@
 import { getSelectedProvider } from '@stacks/connect';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import type { SupportedStacksWallet } from '../../constants/wallets';
 import type { ConnectOptions } from '../../provider/stacks-wallet-provider.types';
@@ -13,19 +13,33 @@ import {
 
 export const useXverse = ({
     address,
+    publicKey,
     provider,
-    onAddressChange,
+    onAccountChange,
     connect,
 }: {
     address: string | undefined;
+    publicKey: string | undefined;
     provider: SupportedStacksWallet | undefined;
-    onAddressChange: (newAddress: string) => void;
+    onAccountChange: (address: string, publicKey: string) => void;
     connect: (
         providerId?: SupportedStacksWallet,
         options?: ConnectOptions
     ) => Promise<void>;
 }) => {
     const [isProviderReady, setIsProviderReady] = useState(false);
+
+    // Mirror current address/publicKey into refs so the accountChange listener
+    // always compares against the latest values without re-mounting the effect.
+    // Keeping them in the dep array tore down and re-ran the setup on every
+    // account switch, which called wallet_connect a second time and prompted
+    // Xverse for re-authorization.
+    const addressRef = useRef(address);
+    const publicKeyRef = useRef(publicKey);
+    useEffect(() => {
+        addressRef.current = address;
+        publicKeyRef.current = publicKey;
+    }, [address, publicKey]);
 
     useEffect(() => {
         if (provider !== 'xverse') return;
@@ -43,8 +57,11 @@ export const useXverse = ({
         void checkProvider();
     }, [provider]);
 
+    // Re-run on connect/disconnect (hasAddress flip), not on account switches.
+    const hasAddress = !!address;
+
     useEffect(() => {
-        if (provider !== 'xverse' || !address || !isProviderReady) return;
+        if (provider !== 'xverse' || !hasAddress || !isProviderReady) return;
 
         let cancelled = false;
         let removeListener: (() => void) | undefined;
@@ -66,8 +83,9 @@ export const useXverse = ({
 
                 extractAndValidateStacksAddress(
                     response?.result?.addresses,
-                    address,
-                    onAddressChange,
+                    addressRef.current,
+                    publicKeyRef.current,
+                    onAccountChange,
                     () => connect('xverse')
                 );
 
@@ -76,8 +94,9 @@ export const useXverse = ({
                     (event: XverseAccountChangeEvent) => {
                         extractAndValidateStacksAddress(
                             event?.addresses,
-                            address,
-                            onAddressChange,
+                            addressRef.current,
+                            publicKeyRef.current,
+                            onAccountChange,
                             () => connect('xverse')
                         );
                     }
@@ -100,5 +119,5 @@ export const useXverse = ({
                 console.error('Failed to remove Xverse listener:', error);
             }
         };
-    }, [address, isProviderReady, onAddressChange, connect, provider]);
+    }, [hasAddress, isProviderReady, onAccountChange, connect, provider]);
 };

--- a/packages/kit/src/provider/stacks-wallet-provider.tsx
+++ b/packages/kit/src/provider/stacks-wallet-provider.tsx
@@ -435,10 +435,23 @@ export const StacksWalletProvider = ({
         [onAddressChange]
     );
 
+    // Xverse emits accountChange with both address and publicKey. We must update
+    // both, otherwise hooks that build unsigned txs (e.g. useSponsoredContractCall)
+    // sign with a stale publicKey and the tx fails verifyOrigin().
+    const handleXverseAccountChange = useCallback(
+        (newAddress: string, newPublicKey: string) => {
+            setAddress(newAddress);
+            setPublicKey(newPublicKey);
+            onAddressChange?.(newAddress);
+        },
+        [onAddressChange]
+    );
+
     useXverse({
         address,
+        publicKey,
         provider,
-        onAddressChange: handleAddressChange,
+        onAccountChange: handleXverseAccountChange,
         connect,
     });
 

--- a/packages/kit/tests/unit/hooks/use-xverse.helpers.test.ts
+++ b/packages/kit/tests/unit/hooks/use-xverse.helpers.test.ts
@@ -26,88 +26,141 @@ describe('shouldSupportAccountChange', () => {
 
 describe('extractAndValidateStacksAddress', () => {
     it('calls connect when addresses is undefined', () => {
-        const onAddressChange = vi.fn();
+        const onAccountChange = vi.fn();
         const connect = vi.fn().mockResolvedValue(undefined);
 
-        extractAndValidateStacksAddress(undefined, 'SP123', onAddressChange, connect);
+        extractAndValidateStacksAddress(undefined, 'SP123', 'pkA', onAccountChange, connect);
 
         expect(connect).toHaveBeenCalled();
-        expect(onAddressChange).not.toHaveBeenCalled();
+        expect(onAccountChange).not.toHaveBeenCalled();
     });
 
     it('calls connect when no stacks account found', () => {
-        const onAddressChange = vi.fn();
+        const onAccountChange = vi.fn();
         const connect = vi.fn().mockResolvedValue(undefined);
 
         extractAndValidateStacksAddress(
-            [{ address: 'bc1qxyz', addressType: 'bitcoin', purpose: 'payment' }],
+            [{ address: 'bc1qxyz', publicKey: 'pkX', addressType: 'bitcoin', purpose: 'payment' }],
             'SP123',
-            onAddressChange,
+            'pkA',
+            onAccountChange,
             connect
         );
 
         expect(connect).toHaveBeenCalled();
-        expect(onAddressChange).not.toHaveBeenCalled();
+        expect(onAccountChange).not.toHaveBeenCalled();
     });
 
-    it('calls onAddressChange when stacks address differs from current', () => {
-        const onAddressChange = vi.fn();
+    it('calls connect when stacks account has no publicKey', () => {
+        const onAccountChange = vi.fn();
         const connect = vi.fn().mockResolvedValue(undefined);
 
         extractAndValidateStacksAddress(
             [{ address: 'SP456', addressType: 'stacks', purpose: 'stacks' }],
             'SP123',
-            onAddressChange,
+            'pkA',
+            onAccountChange,
             connect
         );
 
-        expect(onAddressChange).toHaveBeenCalledWith('SP456');
-        expect(connect).not.toHaveBeenCalled();
+        expect(connect).toHaveBeenCalled();
+        expect(onAccountChange).not.toHaveBeenCalled();
     });
 
-    it('does nothing when stacks address matches current', () => {
-        const onAddressChange = vi.fn();
+    it('calls onAccountChange with both fields when address differs', () => {
+        const onAccountChange = vi.fn();
         const connect = vi.fn().mockResolvedValue(undefined);
 
         extractAndValidateStacksAddress(
-            [{ address: 'SP123', addressType: 'stacks', purpose: 'stacks' }],
+            [{ address: 'SP456', publicKey: 'pkB', addressType: 'stacks', purpose: 'stacks' }],
             'SP123',
-            onAddressChange,
+            'pkA',
+            onAccountChange,
             connect
         );
 
-        expect(onAddressChange).not.toHaveBeenCalled();
+        expect(onAccountChange).toHaveBeenCalledWith('SP456', 'pkB');
+        expect(connect).not.toHaveBeenCalled();
+    });
+
+    it('calls onAccountChange when only publicKey differs', () => {
+        const onAccountChange = vi.fn();
+        const connect = vi.fn().mockResolvedValue(undefined);
+
+        extractAndValidateStacksAddress(
+            [{ address: 'SP123', publicKey: 'pkNew', addressType: 'stacks', purpose: 'stacks' }],
+            'SP123',
+            'pkOld',
+            onAccountChange,
+            connect
+        );
+
+        expect(onAccountChange).toHaveBeenCalledWith('SP123', 'pkNew');
+        expect(connect).not.toHaveBeenCalled();
+    });
+
+    it('calls onAccountChange when current publicKey is undefined', () => {
+        const onAccountChange = vi.fn();
+        const connect = vi.fn().mockResolvedValue(undefined);
+
+        extractAndValidateStacksAddress(
+            [{ address: 'SP123', publicKey: 'pkA', addressType: 'stacks', purpose: 'stacks' }],
+            'SP123',
+            undefined,
+            onAccountChange,
+            connect
+        );
+
+        expect(onAccountChange).toHaveBeenCalledWith('SP123', 'pkA');
+        expect(connect).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when address and publicKey both match', () => {
+        const onAccountChange = vi.fn();
+        const connect = vi.fn().mockResolvedValue(undefined);
+
+        extractAndValidateStacksAddress(
+            [{ address: 'SP123', publicKey: 'pkA', addressType: 'stacks', purpose: 'stacks' }],
+            'SP123',
+            'pkA',
+            onAccountChange,
+            connect
+        );
+
+        expect(onAccountChange).not.toHaveBeenCalled();
         expect(connect).not.toHaveBeenCalled();
     });
 
     it('finds stacks account by purpose field', () => {
-        const onAddressChange = vi.fn();
+        const onAccountChange = vi.fn();
         const connect = vi.fn().mockResolvedValue(undefined);
 
         extractAndValidateStacksAddress(
             [
-                { address: 'bc1qxyz', addressType: 'bitcoin', purpose: 'payment' },
-                { address: 'SP789', addressType: 'other', purpose: 'stacks' },
+                { address: 'bc1qxyz', publicKey: 'pkX', addressType: 'bitcoin', purpose: 'payment' },
+                { address: 'SP789', publicKey: 'pkS', addressType: 'other', purpose: 'stacks' },
             ],
             'SP123',
-            onAddressChange,
+            'pkA',
+            onAccountChange,
             connect
         );
 
-        expect(onAddressChange).toHaveBeenCalledWith('SP789');
+        expect(onAccountChange).toHaveBeenCalledWith('SP789', 'pkS');
     });
 
     it('finds stacks account by addressType field', () => {
-        const onAddressChange = vi.fn();
+        const onAccountChange = vi.fn();
         const connect = vi.fn().mockResolvedValue(undefined);
 
         extractAndValidateStacksAddress(
-            [{ address: 'SP789', addressType: 'stacks', purpose: 'other' }],
+            [{ address: 'SP789', publicKey: 'pkS', addressType: 'stacks', purpose: 'other' }],
             'SP123',
-            onAddressChange,
+            'pkA',
+            onAccountChange,
             connect
         );
 
-        expect(onAddressChange).toHaveBeenCalledWith('SP789');
+        expect(onAccountChange).toHaveBeenCalledWith('SP789', 'pkS');
     });
 });

--- a/packages/kit/tests/unit/hooks/use-xverse.test.ts
+++ b/packages/kit/tests/unit/hooks/use-xverse.test.ts
@@ -39,8 +39,9 @@ describe('useXverse', () => {
             renderHook(() =>
                 useXverse({
                     address: 'SP123',
+                    publicKey: 'pkA',
                     provider: 'leather',
-                    onAddressChange: vi.fn(),
+                    onAccountChange: vi.fn(),
                     connect: vi.fn(),
                 })
             );
@@ -52,8 +53,9 @@ describe('useXverse', () => {
             renderHook(() =>
                 useXverse({
                     address: undefined,
+                    publicKey: undefined,
                     provider: undefined,
-                    onAddressChange: vi.fn(),
+                    onAccountChange: vi.fn(),
                     connect: vi.fn(),
                 })
             );
@@ -76,8 +78,9 @@ describe('useXverse', () => {
                 renderHook(() =>
                     useXverse({
                         address: 'SP123',
+                        publicKey: 'pkA',
                         provider: 'xverse',
-                        onAddressChange: vi.fn(),
+                        onAccountChange: vi.fn(),
                         connect: vi.fn(),
                     })
                 );
@@ -97,8 +100,9 @@ describe('useXverse', () => {
                 renderHook(() =>
                     useXverse({
                         address: 'SP123',
+                        publicKey: 'pkA',
                         provider: 'xverse',
-                        onAddressChange: vi.fn(),
+                        onAccountChange: vi.fn(),
                         connect: vi.fn(),
                     })
                 );
@@ -122,8 +126,9 @@ describe('useXverse', () => {
                 renderHook(() =>
                     useXverse({
                         address: 'SP123',
+                        publicKey: 'pkA',
                         provider: 'xverse',
-                        onAddressChange: vi.fn(),
+                        onAccountChange: vi.fn(),
                         connect: vi.fn(),
                     })
                 );
@@ -154,8 +159,9 @@ describe('useXverse', () => {
                 renderHook(() =>
                     useXverse({
                         address: 'SP123',
+                        publicKey: 'pkA',
                         provider: 'xverse',
-                        onAddressChange: vi.fn(),
+                        onAccountChange: vi.fn(),
                         connect: vi.fn(),
                     })
                 );
@@ -172,7 +178,7 @@ describe('useXverse', () => {
             );
         });
 
-        it('calls extractAndValidateStacksAddress with wallet_connect response', async () => {
+        it('calls extractAndValidateStacksAddress with wallet_connect response and cached publicKey', async () => {
             mockWaitForXverseProvider.mockResolvedValue(true);
             mockGetXverseProductInfo.mockResolvedValue({ version: '2.0.0' });
             mockShouldSupportAccountChange.mockReturnValue(true);
@@ -180,7 +186,7 @@ describe('useXverse', () => {
             const mockAddresses = [
                 {
                     address: 'SP456',
-                    publicKey: 'pk',
+                    publicKey: 'pkB',
                     purpose: 'stacks',
                     addressType: 'stacks',
                     walletType: 'software',
@@ -195,14 +201,15 @@ describe('useXverse', () => {
                 addListener: mockAddListener,
             });
 
-            const onAddressChange = vi.fn();
+            const onAccountChange = vi.fn();
 
             await act(async () => {
                 renderHook(() =>
                     useXverse({
                         address: 'SP123',
+                        publicKey: 'pkA',
                         provider: 'xverse',
-                        onAddressChange,
+                        onAccountChange,
                         connect: vi.fn(),
                     })
                 );
@@ -214,12 +221,13 @@ describe('useXverse', () => {
             ).toHaveBeenCalledWith(
                 mockAddresses,
                 'SP123',
-                onAddressChange,
+                'pkA',
+                onAccountChange,
                 expect.any(Function)
             );
         });
 
-        it('fires extractAndValidateStacksAddress on accountChange event', async () => {
+        it('fires extractAndValidateStacksAddress on accountChange event with cached publicKey', async () => {
             mockWaitForXverseProvider.mockResolvedValue(true);
             mockGetXverseProductInfo.mockResolvedValue({ version: '2.0.0' });
             mockShouldSupportAccountChange.mockReturnValue(true);
@@ -238,14 +246,15 @@ describe('useXverse', () => {
                 addListener: mockAddListener,
             });
 
-            const onAddressChange = vi.fn();
+            const onAccountChange = vi.fn();
 
             await act(async () => {
                 renderHook(() =>
                     useXverse({
                         address: 'SP123',
+                        publicKey: 'pkA',
                         provider: 'xverse',
-                        onAddressChange,
+                        onAccountChange,
                         connect: vi.fn(),
                     })
                 );
@@ -260,7 +269,7 @@ describe('useXverse', () => {
                 addresses: [
                     {
                         address: 'SP789',
-                        publicKey: 'pk',
+                        publicKey: 'pkB',
                         purpose: 'stacks',
                         addressType: 'stacks',
                         walletType: 'software',
@@ -277,7 +286,8 @@ describe('useXverse', () => {
             ).toHaveBeenCalledWith(
                 accountEvent.addresses,
                 'SP123',
-                onAddressChange,
+                'pkA',
+                onAccountChange,
                 expect.any(Function)
             );
         });
@@ -302,8 +312,9 @@ describe('useXverse', () => {
                 const hook = renderHook(() =>
                     useXverse({
                         address: 'SP123',
+                        publicKey: 'pkA',
                         provider: 'xverse',
-                        onAddressChange: vi.fn(),
+                        onAccountChange: vi.fn(),
                         connect: vi.fn(),
                     })
                 );
@@ -342,8 +353,9 @@ describe('useXverse', () => {
                 const hook = renderHook(() =>
                     useXverse({
                         address: 'SP123',
+                        publicKey: 'pkA',
                         provider: 'xverse',
-                        onAddressChange: vi.fn(),
+                        onAccountChange: vi.fn(),
                         connect: vi.fn(),
                     })
                 );
@@ -379,8 +391,9 @@ describe('useXverse', () => {
             const { unmount } = renderHook(() =>
                 useXverse({
                     address: 'SP123',
+                    publicKey: 'pkA',
                     provider: 'xverse',
-                    onAddressChange: vi.fn(),
+                    onAccountChange: vi.fn(),
                     connect: vi.fn(),
                 })
             );

--- a/packages/kit/tests/unit/provider/stacks-wallet-provider.test.ts
+++ b/packages/kit/tests/unit/provider/stacks-wallet-provider.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { renderHook } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { createElement } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -24,16 +24,18 @@ vi.mock('../../../src/utils/get-stacks-wallets', () => ({
     checkIfStacksProviderIsInstalled: () => false,
 }));
 
+const mockGetLocalStorageWallet = vi.fn(() => null as unknown);
 vi.mock('../../../src/utils/get-local-storage-wallet', () => ({
-    getLocalStorageWallet: () => null,
+    getLocalStorageWallet: () => mockGetLocalStorageWallet(),
 }));
 
 vi.mock('../../../src/hooks/use-wallet-connect/use-wallet-connect', () => ({
     useWalletConnect: vi.fn(),
 }));
 
+const mockUseXverse = vi.fn();
 vi.mock('../../../src/hooks/use-xverse/use-xverse', () => ({
-    useXverse: vi.fn(),
+    useXverse: (args: unknown) => mockUseXverse(args),
 }));
 
 vi.mock('@stacks/connect', () => ({
@@ -91,6 +93,8 @@ const wrapper = ({ children }: { children: React.ReactNode }) =>
 
 beforeEach(() => {
     mockGetStacksWallets.mockClear();
+    mockUseXverse.mockClear();
+    mockGetLocalStorageWallet.mockReturnValue(null);
 });
 
 describe('StacksWalletProvider', () => {
@@ -127,5 +131,47 @@ describe('StacksWalletProvider', () => {
         expect(result.current.status).toBe('disconnected');
         expect(result.current.address).toBeUndefined();
         expect(result.current.provider).toBeUndefined();
+    });
+
+    it('Xverse account change updates both address and publicKey', async () => {
+        mockGetStacksWallets.mockReturnValue({
+            supported: ['xverse'] as SupportedStacksWallet[],
+            installed: ['xverse'] as SupportedStacksWallet[],
+        });
+        // Start in a "connected to Xverse" state so the discriminated union
+        // exposes address/publicKey (disconnected branch zeroes them out).
+        mockGetLocalStorageWallet.mockReturnValue({
+            provider: 'xverse',
+            address: 'SP_OLD',
+            publicKey: 'pk_old',
+        });
+
+        const { result } = renderHook(() => useStacksWalletContext(), {
+            wrapper,
+        });
+
+        // Wait for the async loadPersistedWallet effect to apply.
+        await act(async () => {
+            await new Promise((r) => setTimeout(r, 0));
+        });
+
+        expect(result.current.status).toBe('connected');
+        expect(result.current.publicKey).toBe('pk_old');
+
+        // Grab the latest args useXverse was called with — these contain the
+        // provider's onAccountChange handler.
+        const lastCall = mockUseXverse.mock.calls.at(-1)?.[0] as {
+            onAccountChange: (address: string, publicKey: string) => void;
+            publicKey: string | undefined;
+        };
+        expect(lastCall?.publicKey).toBe('pk_old');
+        expect(lastCall?.onAccountChange).toBeTypeOf('function');
+
+        act(() => {
+            lastCall.onAccountChange('SP_NEW', 'pk_new');
+        });
+
+        expect(result.current.address).toBe('SP_NEW');
+        expect(result.current.publicKey).toBe('pk_new');
     });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
     devDependencies:
       '@changesets/cli':
         specifier: ^2.29.8
-        version: 2.29.8(@types/node@22.19.11)
+        version: 2.29.8(@types/node@25.6.2)
       '@commitlint/cli':
         specifier: ^20.4.1
-        version: 20.4.2(@types/node@22.19.11)(typescript@5.9.3)
+        version: 20.4.2(@types/node@25.6.2)(typescript@5.9.3)
       '@commitlint/config-conventional':
         specifier: ^20.4.1
         version: 20.4.2
@@ -36,23 +36,23 @@ importers:
         specifier: workspace:*
         version: link:../../packages/kit
       '@stacks/transactions':
-        specifier: ^7.2.0
-        version: 7.3.1
+        specifier: ^7.4.0
+        version: 7.4.0
       next:
-        specifier: ^16.0.0
-        version: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^16.2.6
+        version: 16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: ^19.2.6
+        version: 19.2.6
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: ^19.2.6
+        version: 19.2.6(react@19.2.6)
     devDependencies:
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.14
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.2
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.7.0
@@ -81,62 +81,62 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.3.0
-        version: 4.7.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1))
+        version: 4.7.0(vite@6.4.1(@types/node@25.6.2)(jiti@2.6.1))
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
       vite:
         specifier: ^6.0.0
-        version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)
+        version: 6.4.1(@types/node@25.6.2)(jiti@2.6.1)
 
   packages/kit:
     dependencies:
       '@stacks/connect':
         specifier: 8.2.6
-        version: 8.2.6(@types/react@19.2.14)(lit@3.3.0)(react@19.2.4)(typescript@5.9.3)(zod@3.22.4)
+        version: 8.2.6(@types/react@19.2.14)(lit@3.3.0)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4)
       bns-v2-sdk:
-        specifier: ^2.1.0
-        version: 2.1.1
+        specifier: ^2.2.0
+        version: 2.2.0
       clarity-abitype:
-        specifier: ^0.4.0
-        version: 0.4.0(@stacks/network@7.3.1)(@stacks/transactions@7.3.1)(typescript@5.9.3)
+        specifier: ^0.6.0
+        version: 0.6.0(@stacks/connect@8.2.6(@types/react@19.2.14)(lit@3.3.0)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4))(@stacks/network@7.3.1)(@stacks/transactions@7.4.0)(typescript@5.9.3)
     devDependencies:
       '@stacks/transactions':
-        specifier: ^7.2.0
-        version: 7.3.1
+        specifier: ^7.4.0
+        version: 7.4.0
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@types/node':
-        specifier: ^22.0.0
-        version: 22.19.11
+        specifier: ^25.6.2
+        version: 25.6.2
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.14
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.2
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/node@22.19.11)(happy-dom@20.7.0)(jiti@2.6.1))
+        version: 3.2.4(vitest@3.2.4(@types/node@25.6.2)(happy-dom@20.9.0)(jiti@2.6.1))
       happy-dom:
-        specifier: ^20.7.0
-        version: 20.7.0
+        specifier: ^20.9.0
+        version: 20.9.0
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: ^19.2.6
+        version: 19.2.6
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: ^19.2.6
+        version: 19.2.6(react@19.2.6)
       tsup:
-        specifier: ^8.3.0
+        specifier: ^8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.11)(happy-dom@20.7.0)(jiti@2.6.1)
+        version: 3.2.4(@types/node@25.6.2)(happy-dom@20.9.0)(jiti@2.6.1)
 
 packages:
 
@@ -925,53 +925,53 @@ packages:
     resolution: {integrity: sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ==}
     engines: {node: '>= 18'}
 
-  '@next/env@16.1.6':
-    resolution: {integrity: sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==}
+  '@next/env@16.2.6':
+    resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
 
-  '@next/swc-darwin-arm64@16.1.6':
-    resolution: {integrity: sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==}
+  '@next/swc-darwin-arm64@16.2.6':
+    resolution: {integrity: sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.1.6':
-    resolution: {integrity: sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==}
+  '@next/swc-darwin-x64@16.2.6':
+    resolution: {integrity: sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.1.6':
-    resolution: {integrity: sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==}
+  '@next/swc-linux-arm64-gnu@16.2.6':
+    resolution: {integrity: sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@16.1.6':
-    resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
+  '@next/swc-linux-arm64-musl@16.2.6':
+    resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@16.1.6':
-    resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
+  '@next/swc-linux-x64-gnu@16.2.6':
+    resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@16.1.6':
-    resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
+  '@next/swc-linux-x64-musl@16.2.6':
+    resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@16.1.6':
-    resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
+  '@next/swc-win32-arm64-msvc@16.2.6':
+    resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.1.6':
-    resolution: {integrity: sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==}
+  '@next/swc-win32-x64-msvc@16.2.6':
+    resolution: {integrity: sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -1270,6 +1270,9 @@ packages:
   '@stacks/transactions@7.3.1':
     resolution: {integrity: sha512-ufnC1BPrOKz5b5gxxdseP3vBrFq1+qx1L6t+J/QnjXULyWdkhtS+LBEqRw2bL5qNteMvU2GhqPgFtYQPzolGbw==}
 
+  '@stacks/transactions@7.4.0':
+    resolution: {integrity: sha512-scsQO3rSNNKcPHp56Wy5OeZiIpQNmmZOORz8bkQKWjzvzycAodtSWmAoHiMFAKSleR1NyeRIz642fReqlZU9tw==}
+
   '@stencil/core@4.43.1':
     resolution: {integrity: sha512-sohOiS8XMJXQnMsxhCgT6Ex8Kl0e0PAzDH9ExYXpDn/5Wo5rliSmABkqU9/dz/l945O/mpeG10rn6jToZJFjKQ==}
     engines: {node: '>=16.0.0', npm: '>=7.10.0'}
@@ -1333,8 +1336,8 @@ packages:
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
-  '@types/node@22.19.11':
-    resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
+  '@types/node@25.6.2':
+    resolution: {integrity: sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -1708,8 +1711,8 @@ packages:
   bn.js@4.12.3:
     resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
 
-  bns-v2-sdk@2.1.1:
-    resolution: {integrity: sha512-my1tYaYJnVVjnogwt67M7b9H0gQ4FCTAbCnMaeasDGnZxDPFeoXIgU9IRLxvjlmkMamgVjb1ODYAIVvzX6at1w==}
+  bns-v2-sdk@2.2.0:
+    resolution: {integrity: sha512-G3xQImNqZqsJRFhM92EJZtozV2ne7JpxHC03YReH4xUTPnO9tRpOoW0+iHmWeSL9OBA+4pd3tasi/btvcutgMQ==}
     engines: {node: '>=16.0.0'}
 
   brace-expansion@1.1.12:
@@ -1827,15 +1830,18 @@ packages:
     resolution: {integrity: sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==}
     engines: {node: '>= 0.10'}
 
-  clarity-abitype@0.4.0:
-    resolution: {integrity: sha512-kx991wMSt6lPs3lINz6Q5/oNdxhhR3cf1qYECay9EGquuzvbz4RzCtRCM8M65nrfdgafqjuFjlzbr6znkvlf5w==}
+  clarity-abitype@0.6.0:
+    resolution: {integrity: sha512-4NhSWB/yuKQtl9u+7hk1xljYNfja2myu/I2VyQM+PexhCfCJ6lm7rGtfdbCGPR1HyEDEmdHwvHd66gAgAvxtpQ==}
     peerDependencies:
       '@stacks/clarinet-sdk': '>= 3.0.0'
+      '@stacks/connect': '>= 8.0.0'
       '@stacks/network': '>= 7.3.0'
       '@stacks/transactions': '>= 7.3.0'
-      typescript: '>=5.1.0'
+      typescript: '>=5.4.0 || >=6.0.0'
     peerDependenciesMeta:
       '@stacks/clarinet-sdk':
+        optional: true
+      '@stacks/connect':
         optional: true
       '@stacks/network':
         optional: true
@@ -2338,8 +2344,8 @@ packages:
   h3@1.15.5:
     resolution: {integrity: sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==}
 
-  happy-dom@20.7.0:
-    resolution: {integrity: sha512-hR/uLYQdngTyEfxnOoa+e6KTcfBFyc1hgFj/Cc144A5JJUuHFYqIEBDcD4FeGqUeKLRZqJ9eN9u7/GDjYEgS1g==}
+  happy-dom@20.9.0:
+    resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
     engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
@@ -2728,8 +2734,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  next@16.1.6:
-    resolution: {integrity: sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==}
+  next@16.2.6:
+    resolution: {integrity: sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -3011,6 +3017,11 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
+  react-dom@19.2.6:
+    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
+    peerDependencies:
+      react: ^19.2.6
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
@@ -3020,6 +3031,10 @@ packages:
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.6:
+    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
     engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
@@ -3388,8 +3403,8 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -3862,7 +3877,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.29.8(@types/node@22.19.11)':
+  '@changesets/cli@2.29.8(@types/node@25.6.2)':
     dependencies:
       '@changesets/apply-release-plan': 7.0.14
       '@changesets/assemble-release-plan': 6.0.9
@@ -3878,7 +3893,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@22.19.11)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.6.2)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       ci-info: 3.9.0
@@ -3977,11 +3992,11 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@commitlint/cli@20.4.2(@types/node@22.19.11)(typescript@5.9.3)':
+  '@commitlint/cli@20.4.2(@types/node@25.6.2)(typescript@5.9.3)':
     dependencies:
       '@commitlint/format': 20.4.0
       '@commitlint/lint': 20.4.2
-      '@commitlint/load': 20.4.0(@types/node@22.19.11)(typescript@5.9.3)
+      '@commitlint/load': 20.4.0(@types/node@25.6.2)(typescript@5.9.3)
       '@commitlint/read': 20.4.0
       '@commitlint/types': 20.4.0
       tinyexec: 1.0.2
@@ -4028,14 +4043,14 @@ snapshots:
       '@commitlint/rules': 20.4.2
       '@commitlint/types': 20.4.0
 
-  '@commitlint/load@20.4.0(@types/node@22.19.11)(typescript@5.9.3)':
+  '@commitlint/load@20.4.0(@types/node@25.6.2)(typescript@5.9.3)':
     dependencies:
       '@commitlint/config-validator': 20.4.0
       '@commitlint/execute-rule': 20.0.0
       '@commitlint/resolve-extends': 20.4.0
       '@commitlint/types': 20.4.0
       cosmiconfig: 9.0.0(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 6.2.0(@types/node@22.19.11)(cosmiconfig@9.0.0(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig-typescript-loader: 6.2.0(@types/node@25.6.2)(cosmiconfig@9.0.0(typescript@5.9.3))(typescript@5.9.3)
       is-plain-obj: 4.1.0
       lodash.mergewith: 4.6.2
       picocolors: 1.1.1
@@ -4401,12 +4416,12 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@inquirer/external-editor@1.0.3(@types/node@22.19.11)':
+  '@inquirer/external-editor@1.0.3(@types/node@25.6.2)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 22.19.11
+      '@types/node': 25.6.2
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -4467,30 +4482,30 @@ snapshots:
 
   '@msgpack/msgpack@3.1.2': {}
 
-  '@next/env@16.1.6': {}
+  '@next/env@16.2.6': {}
 
-  '@next/swc-darwin-arm64@16.1.6':
+  '@next/swc-darwin-arm64@16.2.6':
     optional: true
 
-  '@next/swc-darwin-x64@16.1.6':
+  '@next/swc-darwin-x64@16.2.6':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.1.6':
+  '@next/swc-linux-arm64-gnu@16.2.6':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.1.6':
+  '@next/swc-linux-arm64-musl@16.2.6':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.1.6':
+  '@next/swc-linux-x64-gnu@16.2.6':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.1.6':
+  '@next/swc-linux-x64-musl@16.2.6':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.1.6':
+  '@next/swc-win32-arm64-msvc@16.2.6':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.1.6':
+  '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
   '@noble/ciphers@1.3.0': {}
@@ -4547,12 +4562,12 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-controllers@1.7.17(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(zod@3.22.4)':
+  '@reown/appkit-controllers@1.7.17(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4)':
     dependencies:
       '@reown/appkit-common': 1.7.17(typescript@5.9.3)(zod@3.22.4)
       '@reown/appkit-wallet': 1.7.17(typescript@5.9.3)
       '@walletconnect/universal-provider': 2.21.5(typescript@5.9.3)(zod@3.22.4)
-      valtio: 2.1.5(@types/react@19.2.14)(react@19.2.4)
+      valtio: 2.1.5(@types/react@19.2.14)(react@19.2.6)
       viem: 2.46.2(typescript@5.9.3)(zod@3.22.4)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -4582,14 +4597,14 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-pay@1.7.17(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(zod@3.22.4)':
+  '@reown/appkit-pay@1.7.17(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4)':
     dependencies:
       '@reown/appkit-common': 1.7.17(typescript@5.9.3)(zod@3.22.4)
-      '@reown/appkit-controllers': 1.7.17(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(zod@3.22.4)
-      '@reown/appkit-ui': 1.7.17(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(zod@3.22.4)
-      '@reown/appkit-utils': 1.7.17(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(valtio@2.1.5(@types/react@19.2.14)(react@19.2.4))(zod@3.22.4)
+      '@reown/appkit-controllers': 1.7.17(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4)
+      '@reown/appkit-ui': 1.7.17(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4)
+      '@reown/appkit-utils': 1.7.17(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)(valtio@2.1.5(@types/react@19.2.14)(react@19.2.6))(zod@3.22.4)
       lit: 3.3.0
-      valtio: 2.1.5(@types/react@19.2.14)(react@19.2.4)
+      valtio: 2.1.5(@types/react@19.2.14)(react@19.2.6)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -4622,12 +4637,12 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
-  '@reown/appkit-scaffold-ui@1.7.17(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(valtio@2.1.5(@types/react@19.2.14)(react@19.2.4))(zod@3.22.4)':
+  '@reown/appkit-scaffold-ui@1.7.17(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)(valtio@2.1.5(@types/react@19.2.14)(react@19.2.6))(zod@3.22.4)':
     dependencies:
       '@reown/appkit-common': 1.7.17(typescript@5.9.3)(zod@3.22.4)
-      '@reown/appkit-controllers': 1.7.17(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(zod@3.22.4)
-      '@reown/appkit-ui': 1.7.17(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(zod@3.22.4)
-      '@reown/appkit-utils': 1.7.17(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(valtio@2.1.5(@types/react@19.2.14)(react@19.2.4))(zod@3.22.4)
+      '@reown/appkit-controllers': 1.7.17(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4)
+      '@reown/appkit-ui': 1.7.17(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4)
+      '@reown/appkit-utils': 1.7.17(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)(valtio@2.1.5(@types/react@19.2.14)(react@19.2.6))(zod@3.22.4)
       '@reown/appkit-wallet': 1.7.17(typescript@5.9.3)
       lit: 3.3.0
     transitivePeerDependencies:
@@ -4659,13 +4674,13 @@ snapshots:
       - valtio
       - zod
 
-  '@reown/appkit-siwx@1.7.17(@types/react@19.2.14)(lit@3.3.0)(react@19.2.4)(typescript@5.9.3)(valtio@2.1.5(@types/react@19.2.14)(react@19.2.4))(zod@3.22.4)':
+  '@reown/appkit-siwx@1.7.17(@types/react@19.2.14)(lit@3.3.0)(react@19.2.6)(typescript@5.9.3)(valtio@2.1.5(@types/react@19.2.14)(react@19.2.6))(zod@3.22.4)':
     dependencies:
       '@reown/appkit-common': 1.7.17(typescript@5.9.3)(zod@3.22.4)
-      '@reown/appkit-controllers': 1.7.17(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(zod@3.22.4)
-      '@reown/appkit-scaffold-ui': 1.7.17(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(valtio@2.1.5(@types/react@19.2.14)(react@19.2.4))(zod@3.22.4)
-      '@reown/appkit-ui': 1.7.17(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(zod@3.22.4)
-      '@reown/appkit-utils': 1.7.17(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(valtio@2.1.5(@types/react@19.2.14)(react@19.2.4))(zod@3.22.4)
+      '@reown/appkit-controllers': 1.7.17(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4)
+      '@reown/appkit-scaffold-ui': 1.7.17(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)(valtio@2.1.5(@types/react@19.2.14)(react@19.2.6))(zod@3.22.4)
+      '@reown/appkit-ui': 1.7.17(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4)
+      '@reown/appkit-utils': 1.7.17(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)(valtio@2.1.5(@types/react@19.2.14)(react@19.2.6))(zod@3.22.4)
       bip322-js: 2.0.0
       bs58: 6.0.0
       lit: 3.3.0
@@ -4701,10 +4716,10 @@ snapshots:
       - zod
     optional: true
 
-  '@reown/appkit-ui@1.7.17(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(zod@3.22.4)':
+  '@reown/appkit-ui@1.7.17(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4)':
     dependencies:
       '@reown/appkit-common': 1.7.17(typescript@5.9.3)(zod@3.22.4)
-      '@reown/appkit-controllers': 1.7.17(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(zod@3.22.4)
+      '@reown/appkit-controllers': 1.7.17(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4)
       '@reown/appkit-wallet': 1.7.17(typescript@5.9.3)
       lit: 3.3.0
       qrcode: 1.5.3
@@ -4736,9 +4751,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-universal-connector@1.7.17(@types/react@19.2.14)(lit@3.3.0)(react@19.2.4)(typescript@5.9.3)(zod@3.22.4)':
+  '@reown/appkit-universal-connector@1.7.17(@types/react@19.2.14)(lit@3.3.0)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4)':
     dependencies:
-      '@reown/appkit': 1.7.17(@types/react@19.2.14)(lit@3.3.0)(react@19.2.4)(typescript@5.9.3)(zod@3.22.4)
+      '@reown/appkit': 1.7.17(@types/react@19.2.14)(lit@3.3.0)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4)
       '@reown/appkit-common': 1.7.17(typescript@5.9.3)(zod@3.22.4)
       '@walletconnect/types': 2.21.5
       '@walletconnect/universal-provider': 2.21.5(typescript@5.9.3)(zod@3.22.4)
@@ -4772,16 +4787,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-utils@1.7.17(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(valtio@2.1.5(@types/react@19.2.14)(react@19.2.4))(zod@3.22.4)':
+  '@reown/appkit-utils@1.7.17(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)(valtio@2.1.5(@types/react@19.2.14)(react@19.2.6))(zod@3.22.4)':
     dependencies:
       '@reown/appkit-common': 1.7.17(typescript@5.9.3)(zod@3.22.4)
-      '@reown/appkit-controllers': 1.7.17(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(zod@3.22.4)
+      '@reown/appkit-controllers': 1.7.17(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4)
       '@reown/appkit-polyfills': 1.7.17
       '@reown/appkit-wallet': 1.7.17(typescript@5.9.3)
       '@wallet-standard/wallet': 1.1.0
       '@walletconnect/logger': 2.1.2
       '@walletconnect/universal-provider': 2.21.5(typescript@5.9.3)(zod@3.22.4)
-      valtio: 2.1.5(@types/react@19.2.14)(react@19.2.4)
+      valtio: 2.1.5(@types/react@19.2.14)(react@19.2.6)
       viem: 2.46.2(typescript@5.9.3)(zod@3.22.4)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -4822,24 +4837,24 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@reown/appkit@1.7.17(@types/react@19.2.14)(lit@3.3.0)(react@19.2.4)(typescript@5.9.3)(zod@3.22.4)':
+  '@reown/appkit@1.7.17(@types/react@19.2.14)(lit@3.3.0)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4)':
     dependencies:
       '@reown/appkit-common': 1.7.17(typescript@5.9.3)(zod@3.22.4)
-      '@reown/appkit-controllers': 1.7.17(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(zod@3.22.4)
-      '@reown/appkit-pay': 1.7.17(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(zod@3.22.4)
+      '@reown/appkit-controllers': 1.7.17(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4)
+      '@reown/appkit-pay': 1.7.17(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4)
       '@reown/appkit-polyfills': 1.7.17
-      '@reown/appkit-scaffold-ui': 1.7.17(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(valtio@2.1.5(@types/react@19.2.14)(react@19.2.4))(zod@3.22.4)
-      '@reown/appkit-ui': 1.7.17(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(zod@3.22.4)
-      '@reown/appkit-utils': 1.7.17(@types/react@19.2.14)(react@19.2.4)(typescript@5.9.3)(valtio@2.1.5(@types/react@19.2.14)(react@19.2.4))(zod@3.22.4)
+      '@reown/appkit-scaffold-ui': 1.7.17(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)(valtio@2.1.5(@types/react@19.2.14)(react@19.2.6))(zod@3.22.4)
+      '@reown/appkit-ui': 1.7.17(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4)
+      '@reown/appkit-utils': 1.7.17(@types/react@19.2.14)(react@19.2.6)(typescript@5.9.3)(valtio@2.1.5(@types/react@19.2.14)(react@19.2.6))(zod@3.22.4)
       '@reown/appkit-wallet': 1.7.17(typescript@5.9.3)
       '@walletconnect/universal-provider': 2.21.5(typescript@5.9.3)(zod@3.22.4)
       bs58: 6.0.0
       semver: 7.7.2
-      valtio: 2.1.5(@types/react@19.2.14)(react@19.2.4)
+      valtio: 2.1.5(@types/react@19.2.14)(react@19.2.6)
       viem: 2.46.2(typescript@5.9.3)(zod@3.22.4)
     optionalDependencies:
       '@lit/react': 1.0.8(@types/react@19.2.14)
-      '@reown/appkit-siwx': 1.7.17(@types/react@19.2.14)(lit@3.3.0)(react@19.2.4)(typescript@5.9.3)(valtio@2.1.5(@types/react@19.2.14)(react@19.2.4))(zod@3.22.4)
+      '@reown/appkit-siwx': 1.7.17(@types/react@19.2.14)(lit@3.3.0)(react@19.2.6)(typescript@5.9.3)(valtio@2.1.5(@types/react@19.2.14)(react@19.2.6))(zod@3.22.4)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -4994,17 +5009,17 @@ snapshots:
     dependencies:
       '@stencil/core': 4.43.1
 
-  '@stacks/connect@8.2.6(@types/react@19.2.14)(lit@3.3.0)(react@19.2.4)(typescript@5.9.3)(zod@3.22.4)':
+  '@stacks/connect@8.2.6(@types/react@19.2.14)(lit@3.3.0)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4)':
     dependencies:
-      '@reown/appkit': 1.7.17(@types/react@19.2.14)(lit@3.3.0)(react@19.2.4)(typescript@5.9.3)(zod@3.22.4)
-      '@reown/appkit-universal-connector': 1.7.17(@types/react@19.2.14)(lit@3.3.0)(react@19.2.4)(typescript@5.9.3)(zod@3.22.4)
+      '@reown/appkit': 1.7.17(@types/react@19.2.14)(lit@3.3.0)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4)
+      '@reown/appkit-universal-connector': 1.7.17(@types/react@19.2.14)(lit@3.3.0)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4)
       '@scure/base': 1.2.6
       '@stacks/common': 7.3.1
       '@stacks/connect-ui': 8.1.2
       '@stacks/network': 7.3.1
       '@stacks/network-v6': '@stacks/network@6.17.0'
       '@stacks/profile': 7.3.1
-      '@stacks/transactions': 7.3.1
+      '@stacks/transactions': 7.4.0
       '@stacks/transactions-v6': '@stacks/transactions@6.17.0'
       type-fest: 5.4.4
     transitivePeerDependencies:
@@ -5054,7 +5069,7 @@ snapshots:
     dependencies:
       '@stacks/common': 7.3.1
       '@stacks/network': 7.3.1
-      '@stacks/transactions': 7.3.1
+      '@stacks/transactions': 7.4.0
       jsontokens: 4.0.1
       schema-inspector: 2.1.0
       zone-file: 2.0.0-beta.3
@@ -5073,6 +5088,17 @@ snapshots:
       - encoding
 
   '@stacks/transactions@7.3.1':
+    dependencies:
+      '@noble/hashes': 1.1.5
+      '@noble/secp256k1': 1.7.1
+      '@stacks/common': 7.3.1
+      '@stacks/network': 7.3.1
+      c32check: 2.0.0
+      lodash.clonedeep: 4.5.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@stacks/transactions@7.4.0':
     dependencies:
       '@noble/hashes': 1.1.5
       '@noble/secp256k1': 1.7.1
@@ -5109,12 +5135,12 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@testing-library/dom': 10.4.1
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -5144,7 +5170,7 @@ snapshots:
 
   '@types/bn.js@5.2.0':
     dependencies:
-      '@types/node': 22.19.11
+      '@types/node': 25.6.2
 
   '@types/chai@5.2.3':
     dependencies:
@@ -5163,9 +5189,9 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@22.19.11':
+  '@types/node@25.6.2':
     dependencies:
-      undici-types: 6.21.0
+      undici-types: 7.19.2
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -5181,7 +5207,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 22.19.11
+      '@types/node': 25.6.2
 
   '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -5274,7 +5300,7 @@ snapshots:
       '@typescript-eslint/types': 8.56.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.6.2)(jiti@2.6.1))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -5282,11 +5308,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)
+      vite: 6.4.1(@types/node@25.6.2)(jiti@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@22.19.11)(happy-dom@20.7.0)(jiti@2.6.1))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@25.6.2)(happy-dom@20.9.0)(jiti@2.6.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -5301,7 +5327,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@22.19.11)(happy-dom@20.7.0)(jiti@2.6.1)
+      vitest: 3.2.4(@types/node@25.6.2)(happy-dom@20.9.0)(jiti@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5313,13 +5339,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1))':
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@25.6.2)(jiti@2.6.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)
+      vite: 6.4.1(@types/node@25.6.2)(jiti@2.6.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -5831,11 +5857,11 @@ snapshots:
   bn.js@4.12.3:
     optional: true
 
-  bns-v2-sdk@2.1.1:
+  bns-v2-sdk@2.2.0:
     dependencies:
       '@stacks/common': 6.16.0
       '@stacks/network': 6.17.0
-      '@stacks/transactions': 7.3.1
+      '@stacks/transactions': 7.4.0
       axios: 1.13.5
     transitivePeerDependencies:
       - debug
@@ -5984,10 +6010,11 @@ snapshots:
       to-buffer: 1.2.2
     optional: true
 
-  clarity-abitype@0.4.0(@stacks/network@7.3.1)(@stacks/transactions@7.3.1)(typescript@5.9.3):
+  clarity-abitype@0.6.0(@stacks/connect@8.2.6(@types/react@19.2.14)(lit@3.3.0)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4))(@stacks/network@7.3.1)(@stacks/transactions@7.4.0)(typescript@5.9.3):
     optionalDependencies:
+      '@stacks/connect': 8.2.6(@types/react@19.2.14)(lit@3.3.0)(react@19.2.6)(typescript@5.9.3)(zod@3.22.4)
       '@stacks/network': 7.3.1
-      '@stacks/transactions': 7.3.1
+      '@stacks/transactions': 7.4.0
       typescript: 5.9.3
 
   client-only@0.0.1: {}
@@ -6046,9 +6073,9 @@ snapshots:
   core-util-is@1.0.3:
     optional: true
 
-  cosmiconfig-typescript-loader@6.2.0(@types/node@22.19.11)(cosmiconfig@9.0.0(typescript@5.9.3))(typescript@5.9.3):
+  cosmiconfig-typescript-loader@6.2.0(@types/node@25.6.2)(cosmiconfig@9.0.0(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
-      '@types/node': 22.19.11
+      '@types/node': 25.6.2
       cosmiconfig: 9.0.0(typescript@5.9.3)
       jiti: 2.6.1
       typescript: 5.9.3
@@ -6563,9 +6590,9 @@ snapshots:
       ufo: 1.6.3
       uncrypto: 0.1.3
 
-  happy-dom@20.7.0:
+  happy-dom@20.9.0:
     dependencies:
-      '@types/node': 22.19.11
+      '@types/node': 25.6.2
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       entities: 7.0.1
@@ -6921,25 +6948,25 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      '@next/env': 16.1.6
+      '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.0
       caniuse-lite: 1.0.30001774
       postcss: 8.4.31
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(react@19.2.4)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      styled-jsx: 5.1.6(react@19.2.6)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.1.6
-      '@next/swc-darwin-x64': 16.1.6
-      '@next/swc-linux-arm64-gnu': 16.1.6
-      '@next/swc-linux-arm64-musl': 16.1.6
-      '@next/swc-linux-x64-gnu': 16.1.6
-      '@next/swc-linux-x64-musl': 16.1.6
-      '@next/swc-win32-arm64-msvc': 16.1.6
-      '@next/swc-win32-x64-msvc': 16.1.6
+      '@next/swc-darwin-arm64': 16.2.6
+      '@next/swc-darwin-x64': 16.2.6
+      '@next/swc-linux-arm64-gnu': 16.2.6
+      '@next/swc-linux-arm64-musl': 16.2.6
+      '@next/swc-linux-x64-gnu': 16.2.6
+      '@next/swc-linux-x64-musl': 16.2.6
+      '@next/swc-win32-arm64-msvc': 16.2.6
+      '@next/swc-win32-x64-msvc': 16.2.6
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -7204,11 +7231,18 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
+  react-dom@19.2.6(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      scheduler: 0.27.0
+
   react-is@17.0.2: {}
 
   react-refresh@0.17.0: {}
 
   react@19.2.4: {}
+
+  react@19.2.6: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -7460,10 +7494,10 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  styled-jsx@5.1.6(react@19.2.4):
+  styled-jsx@5.1.6(react@19.2.6):
     dependencies:
       client-only: 0.0.1
-      react: 19.2.4
+      react: 19.2.6
 
   sucrase@3.35.1:
     dependencies:
@@ -7615,7 +7649,7 @@ snapshots:
 
   undici-types@5.26.5: {}
 
-  undici-types@6.21.0: {}
+  undici-types@7.19.2: {}
 
   universalify@0.1.2: {}
 
@@ -7644,12 +7678,12 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  valtio@2.1.5(@types/react@19.2.14)(react@19.2.4):
+  valtio@2.1.5(@types/react@19.2.14)(react@19.2.6):
     dependencies:
       proxy-compare: 3.0.1
     optionalDependencies:
       '@types/react': 19.2.14
-      react: 19.2.4
+      react: 19.2.6
 
   varuint-bitcoin@1.1.2:
     dependencies:
@@ -7708,13 +7742,13 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite-node@3.2.4(@types/node@22.19.11)(jiti@2.6.1):
+  vite-node@3.2.4(@types/node@25.6.2)(jiti@2.6.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)
+      vite: 6.4.1(@types/node@25.6.2)(jiti@2.6.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -7729,7 +7763,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1):
+  vite@6.4.1(@types/node@25.6.2)(jiti@2.6.1):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -7738,15 +7772,15 @@ snapshots:
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 22.19.11
+      '@types/node': 25.6.2
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vitest@3.2.4(@types/node@22.19.11)(happy-dom@20.7.0)(jiti@2.6.1):
+  vitest@3.2.4(@types/node@25.6.2)(happy-dom@20.9.0)(jiti@2.6.1):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@25.6.2)(jiti@2.6.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -7764,12 +7798,12 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)
-      vite-node: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)
+      vite: 6.4.1(@types/node@25.6.2)(jiti@2.6.1)
+      vite-node: 3.2.4(@types/node@25.6.2)(jiti@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.19.11
-      happy-dom: 20.7.0
+      '@types/node': 25.6.2
+      happy-dom: 20.9.0
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
## Summary
- Cached `publicKey` is now refreshed alongside `address` when Xverse emits `accountChange`, so `useSponsoredContractCall` builds unsigned transactions with the active account's public key and the resulting signed tx passes `verifyOrigin()`.
- Helper signature: `extractAndValidateStacksAddress` now takes `currentPublicKey` and calls `onAccountChange(address, publicKey)`. Triggers when either address or publicKey differs.
- Provider gains `handleXverseAccountChange` that calls both `setAddress` and `setPublicKey`. WalletConnect path is unchanged (out of scope per the original report — same gap exists for WC and is a follow-up).
- `useXverse` mirrors current `address`/`publicKey` into refs and gates the setup effect on a `hasAddress` boolean instead of the raw values. Avoids tearing the listener down and re-invoking `wallet_connect` on every in-wallet account switch.
- Next.js example modernized: drops the removed `useSignTransaction`, surfaces the connected `publicKey` at the top, and adds a sponsored-call demo that runs `deserializeTransaction(signedTx).verifyOrigin()` client-side — no sponsor service needed to validate the fix.

## Why
Before this change, `useSponsoredContractCall` read a stale `publicKey` from provider state after the user switched accounts inside Xverse. `makeUnsignedContractCall({ publicKey })` produced a tx with `signer = hash160(A)`, Xverse signed with account B, and any sponsor service running `tx.verifyOrigin()` rejected it.

Xverse's `accountChange` event already carries the new account's `publicKey`; the kit just wasn't propagating it.

## Test plan
- [x] `pnpm test` — 222 passing (27 files), including new coverage for publicKey-only changes, missing-publicKey fallback, and a provider-level test asserting both fields update via `handleXverseAccountChange`.
- [x] `pnpm lint` / `pnpm typecheck` clean.
- [x] `pnpm build` (kit) + `pnpm build` (examples/nextjs) clean.
- [ ] Manual: connect Xverse with account A → switch to B inside Xverse → confirm address + publicKey at top of example page update → click "Sign Sponsored Call" → `verifyOrigin() passed` in green. Repeat with account B → C.
- [ ] Manual regression: Leather / OKX / WalletConnect connect + sign flows unchanged.

## Out of scope
- Reactive publicKey support for Leather, OKX, WalletConnect — same gap exists in `useWalletConnect`'s address change handler; left for a follow-up per the original report.
- Fixing Xverse itself so it refuses to sign when the declared signer doesn't match the active account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
